### PR TITLE
feat: database schema creation

### DIFF
--- a/api/drizzle.config.ts
+++ b/api/drizzle.config.ts
@@ -6,7 +6,7 @@ if (!process.env.DATABASE_URL) {
 }
 
 export default defineConfig({
-  schema: './src/core/database/schema/*',
+  schema: './src/core/database/schemas/*',
   out: './src/core/database/migrations',
   dialect: 'postgresql',
   casing: 'snake_case',

--- a/api/src/core/database/migrations/0000_thick_white_queen.sql
+++ b/api/src/core/database/migrations/0000_thick_white_queen.sql
@@ -1,0 +1,85 @@
+CREATE TYPE "public"."subscription_availability" AS ENUM('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday');--> statement-breakpoint
+CREATE TYPE "public"."subscription_status" AS ENUM('pending', 'received', 'completed', 'waiting_list');--> statement-breakpoint
+CREATE TABLE "events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "subscription_options" (
+	"id" text PRIMARY KEY NOT NULL,
+	"subscription_id" text,
+	"team_instance_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "subscriptions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"emergency_contact_name" text NOT NULL,
+	"emergency_contact_phone" text NOT NULL,
+	"is_newbie" boolean DEFAULT false NOT NULL,
+	"status" "subscription_status" DEFAULT 'pending' NOT NULL,
+	"availability" "subscription_availability"[] DEFAULT '{}',
+	"has_coordinator_experience" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "team_instances" (
+	"id" text PRIMARY KEY NOT NULL,
+	"template_id" text,
+	"event_id" text,
+	"first_coordinator_id" text,
+	"second_coordinator_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "team_memberships" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"team_instance_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "team_template" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"key" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text NOT NULL,
+	"phone" text NOT NULL,
+	"name" text NOT NULL,
+	"nickname" text NOT NULL,
+	"date_of_birth" timestamp NOT NULL,
+	"has_music_skills" boolean DEFAULT false NOT NULL,
+	"has_acting_skills" boolean DEFAULT false NOT NULL,
+	"has_dancing_skills" boolean DEFAULT false NOT NULL,
+	"has_singing_skills" boolean DEFAULT false NOT NULL,
+	"has_manual_skills" boolean DEFAULT false NOT NULL,
+	"has_cooking_skills" boolean DEFAULT false NOT NULL,
+	"has_communication_skills" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "subscription_options" ADD CONSTRAINT "subscription_options_subscription_id_subscriptions_id_fk" FOREIGN KEY ("subscription_id") REFERENCES "public"."subscriptions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscription_options" ADD CONSTRAINT "subscription_options_team_instance_id_team_instances_id_fk" FOREIGN KEY ("team_instance_id") REFERENCES "public"."team_instances"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD CONSTRAINT "subscriptions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_instances" ADD CONSTRAINT "team_instances_template_id_team_template_id_fk" FOREIGN KEY ("template_id") REFERENCES "public"."team_template"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_instances" ADD CONSTRAINT "team_instances_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_instances" ADD CONSTRAINT "team_instances_first_coordinator_id_users_id_fk" FOREIGN KEY ("first_coordinator_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_instances" ADD CONSTRAINT "team_instances_second_coordinator_id_users_id_fk" FOREIGN KEY ("second_coordinator_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_memberships" ADD CONSTRAINT "team_memberships_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_memberships" ADD CONSTRAINT "team_memberships_team_instance_id_team_instances_id_fk" FOREIGN KEY ("team_instance_id") REFERENCES "public"."team_instances"("id") ON DELETE no action ON UPDATE no action;

--- a/api/src/core/database/migrations/meta/0000_snapshot.json
+++ b/api/src/core/database/migrations/meta/0000_snapshot.json
@@ -1,0 +1,600 @@
+{
+  "id": "30cca804-b969-45d4-bee2-6f520b1b5362",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_options": {
+      "name": "subscription_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_options_subscription_id_subscriptions_id_fk": {
+          "name": "subscription_options_subscription_id_subscriptions_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscription_options_team_instance_id_team_instances_id_fk": {
+          "name": "subscription_options_team_instance_id_team_instances_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_newbie": {
+          "name": "is_newbie",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "subscription_availability[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "has_coordinator_experience": {
+          "name": "has_coordinator_experience",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_instances": {
+      "name": "team_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_coordinator_id": {
+          "name": "first_coordinator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_coordinator_id": {
+          "name": "second_coordinator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_instances_template_id_team_template_id_fk": {
+          "name": "team_instances_template_id_team_template_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "team_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_event_id_events_id_fk": {
+          "name": "team_instances_event_id_events_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_first_coordinator_id_users_id_fk": {
+          "name": "team_instances_first_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "first_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_second_coordinator_id_users_id_fk": {
+          "name": "team_instances_second_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "second_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_instance_id_team_instances_id_fk": {
+          "name": "team_memberships_team_instance_id_team_instances_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_template": {
+      "name": "team_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_music_skills": {
+          "name": "has_music_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_acting_skills": {
+          "name": "has_acting_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dancing_skills": {
+          "name": "has_dancing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_singing_skills": {
+          "name": "has_singing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_manual_skills": {
+          "name": "has_manual_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_cooking_skills": {
+          "name": "has_cooking_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_communication_skills": {
+          "name": "has_communication_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.subscription_availability": {
+      "name": "subscription_availability",
+      "schema": "public",
+      "values": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "received",
+        "completed",
+        "waiting_list"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/core/database/migrations/meta/_journal.json
+++ b/api/src/core/database/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1750107554424,
+      "tag": "0000_thick_white_queen",
+      "breakpoints": true
+    }
+  ]
+}

--- a/api/src/core/database/schemas/events.ts
+++ b/api/src/core/database/schemas/events.ts
@@ -1,0 +1,9 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const events = pgTable('events', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})

--- a/api/src/core/database/schemas/index.ts
+++ b/api/src/core/database/schemas/index.ts
@@ -1,0 +1,17 @@
+import { users } from './users.ts'
+import { teamInstances } from './team-instances.ts'
+import { subscriptionOptions } from './subscription-options.ts'
+import { subscriptions } from './subscriptions.ts'
+import { events } from './events.ts'
+import { teamMemberships } from './team-memberships.ts'
+import { teamTemplates } from './team-templates.ts'
+
+export const schema = {
+  events,
+  subscriptionOptions,
+  subscriptions,
+  teamInstances,
+  teamMemberships,
+  teamTemplates,
+  users,
+}

--- a/api/src/core/database/schemas/subscription-options.ts
+++ b/api/src/core/database/schemas/subscription-options.ts
@@ -1,0 +1,11 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { subscriptions } from './subscriptions.ts'
+import { teamInstances } from './team-instances.ts'
+
+export const subscriptionOptions = pgTable('subscription_options', {
+  id: text('id').primaryKey(),
+  subscriptionId: text('subscription_id').references(() => subscriptions.id),
+  teamInstanceId: text('team_instance_id').references(() => teamInstances.id),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})

--- a/api/src/core/database/schemas/subscriptions.ts
+++ b/api/src/core/database/schemas/subscriptions.ts
@@ -1,0 +1,34 @@
+import { pgTable, text, timestamp, boolean, pgEnum } from 'drizzle-orm/pg-core'
+import { users } from './users.ts'
+
+export const subscriptionStatus = pgEnum('subscription_status', [
+  'pending',
+  'received',
+  'completed',
+  'waiting_list',
+])
+
+export const subscriptionAvailability = pgEnum('subscription_availability', [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+])
+
+export const subscriptions = pgTable('subscriptions', {
+  id: text('id').primaryKey(),
+  userId: text('user_id').references(() => users.id),
+  emergencyContactName: text('emergency_contact_name').notNull(),
+  emergencyContactPhone: text('emergency_contact_phone').notNull(),
+  isNewbie: boolean('is_newbie').notNull().default(false),
+  status: subscriptionStatus().notNull().default('pending'),
+  availability: subscriptionAvailability().notNull().array().default([]),
+  hasCoordinatorExperience: boolean('has_coordinator_experience')
+    .notNull()
+    .default(false),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})

--- a/api/src/core/database/schemas/team-instances.ts
+++ b/api/src/core/database/schemas/team-instances.ts
@@ -1,0 +1,14 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { teamTemplates } from './team-templates.ts'
+import { users } from './users.ts'
+import { events } from './events.ts'
+
+export const teamInstances = pgTable('team_instances', {
+  id: text('id').primaryKey(),
+  templateId: text('template_id').references(() => teamTemplates.id),
+  eventId: text('event_id').references(() => events.id),
+  firstCoordinatorId: text('first_coordinator_id').references(() => users.id),
+  secondCoordinatorId: text('second_coordinator_id').references(() => users.id),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})

--- a/api/src/core/database/schemas/team-memberships.ts
+++ b/api/src/core/database/schemas/team-memberships.ts
@@ -1,0 +1,11 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { users } from './users.ts'
+import { teamInstances } from './team-instances.ts'
+
+export const teamMemberships = pgTable('team_memberships', {
+  id: text('id').primaryKey(),
+  userId: text('user_id').references(() => users.id),
+  teamInstanceId: text('team_instance_id').references(() => teamInstances.id),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})

--- a/api/src/core/database/schemas/team-templates.ts
+++ b/api/src/core/database/schemas/team-templates.ts
@@ -1,0 +1,10 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const teamTemplates = pgTable('team_template', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  key: text('key').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})

--- a/api/src/core/database/schemas/users.ts
+++ b/api/src/core/database/schemas/users.ts
@@ -1,0 +1,21 @@
+import { pgTable, text, timestamp, boolean } from 'drizzle-orm/pg-core'
+
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull(),
+  phone: text('phone').notNull(),
+  name: text('name').notNull(),
+  nickname: text('nickname').notNull(),
+  dateOfBirth: timestamp('date_of_birth').notNull(),
+  hasMusicSkills: boolean('has_music_skills').notNull().default(false),
+  hasActingSkills: boolean('has_acting_skills').notNull().default(false),
+  hasDancingSkills: boolean('has_dancing_skills').notNull().default(false),
+  hasSingingSkills: boolean('has_singing_skills').notNull().default(false),
+  hasManualSkills: boolean('has_manual_skills').notNull().default(false),
+  hasCookingSkills: boolean('has_cooking_skills').notNull().default(false),
+  hasCommunicationSkills: boolean('has_communication_skills')
+    .notNull()
+    .default(false),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})


### PR DESCRIPTION
### Overview

Resolves: #5
Database schema creation with Drizzle.

### Solution

- Creates the database schemas for each table using `drizzle-orm/pg-core`.
- Generates the migration by running `npx drizzle-kit generate`.
- Applies the migrations with `npx drizzle-kit migrate`.
