### PR TITLE
feat(team-template): get single team template

### DIFF
--- a/api/src/features/team/application/TeamTemplates.ts
+++ b/api/src/features/team/application/TeamTemplates.ts
@@ -15,6 +15,16 @@ class TeamTemplates {
     const result = await teamRepository.insertTeamTemplate(input)
     return result
   }
+
+  async getTeamTemplateById(id: string) {
+    const teamTemplate = await teamRepository.getTeamTemplateById(id)
+
+    if (!teamTemplate) {
+      return undefined
+    }
+
+    return teamTemplate
+  }
 }
 
 export const teamTemplatesApp = new TeamTemplates()

--- a/api/src/features/team/domain/TeamRepository.ts
+++ b/api/src/features/team/domain/TeamRepository.ts
@@ -6,4 +6,5 @@ import {
 export interface TeamRepository {
   insertTeamTemplate: (input: TeamTemplateInput) => Promise<string>
   getTeamTemplateByKey: (key: string) => Promise<TeamTemplateModel | undefined>
+  getTeamTemplateById: (id: string) => Promise<TeamTemplateModel | undefined>
 }

--- a/api/src/features/team/http/team-templates-routes.ts
+++ b/api/src/features/team/http/team-templates-routes.ts
@@ -23,6 +23,10 @@ const createTeamTemplateBodySchema = z.object({
   name: z.string(),
 })
 
+const getTeamTemplateParamSchema = z.object({
+  teamTemplateId: z.uuid(),
+})
+
 export function teamTemplateRoutes(server: FastifyServerInstance) {
   return () => {
     server.post(
@@ -45,6 +49,30 @@ export function teamTemplateRoutes(server: FastifyServerInstance) {
           .code(201)
           .header('location', `/teams/templates/${resultId}`)
           .send(resultId)
+      }
+    )
+
+    server.get(
+      '/teams/templates/:teamTemplateId',
+      {
+        schema: {
+          params: getTeamTemplateParamSchema,
+        },
+      },
+      async (request, reply) => {
+        const { teamTemplateId } = request.params
+        const teamTemplate =
+          await teamTemplatesApp.getTeamTemplateById(teamTemplateId)
+
+        if (!teamTemplate) {
+          return reply.code(404).send({
+            message: 'Team template not found',
+          })
+        }
+
+        return reply.code(200).send({
+          teamTemplate,
+        })
       }
     )
   }

--- a/api/src/features/team/repository/DrizzleTeamRepository.ts
+++ b/api/src/features/team/repository/DrizzleTeamRepository.ts
@@ -5,7 +5,7 @@ import type { TeamRepository } from '../domain/TeamRepository.ts'
 
 class DrizzleTeamRepository implements TeamRepository {
   async insertTeamTemplate(input: {
-    description?: string
+    description?: string | null
     key: string
     name: string
   }) {
@@ -28,6 +28,19 @@ class DrizzleTeamRepository implements TeamRepository {
       .selectDistinct()
       .from(schema.teamTemplates)
       .where(eq(schema.teamTemplates.key, key))
+
+    if (result[0]) {
+      return result[0]
+    }
+
+    return undefined
+  }
+
+  async getTeamTemplateById(id: string) {
+    const result = await db
+      .selectDistinct()
+      .from(schema.teamTemplates)
+      .where(eq(schema.teamTemplates.id, id))
 
     if (result[0]) {
       return result[0]


### PR DESCRIPTION
### Overview

Resolves: #37

Adds get team template endpoint.

### Solution

- Creates a new `GET /teams/templates/:teamTemplateId` route to team templates routes.
- Adds team template id UUID validation with Zod.
- Adds a new `getTeamTemplateById` repository method.
- Adds a new `getTeamTemplate` application method.

