### PR TITLE
feat(team-template): list all

### DIFF
--- a/api/src/core/database/migrations/0003_mute_may_parker.sql
+++ b/api/src/core/database/migrations/0003_mute_may_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "team_template" ADD CONSTRAINT "team_template_key_unique" UNIQUE("key");

--- a/api/src/core/database/migrations/meta/0003_snapshot.json
+++ b/api/src/core/database/migrations/meta/0003_snapshot.json
@@ -1,0 +1,609 @@
+{
+  "id": "5fe222ea-ce62-498c-a437-d096039063bf",
+  "prevId": "30fb60f1-f678-4c64-95ea-4ebbbd75030f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_options": {
+      "name": "subscription_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_options_subscription_id_subscriptions_id_fk": {
+          "name": "subscription_options_subscription_id_subscriptions_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscription_options_team_instance_id_team_instances_id_fk": {
+          "name": "subscription_options_team_instance_id_team_instances_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_newbie": {
+          "name": "is_newbie",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "subscription_availability[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "has_coordinator_experience": {
+          "name": "has_coordinator_experience",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_instances": {
+      "name": "team_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_coordinator_id": {
+          "name": "first_coordinator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_coordinator_id": {
+          "name": "second_coordinator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_instances_template_id_team_template_id_fk": {
+          "name": "team_instances_template_id_team_template_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "team_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_event_id_events_id_fk": {
+          "name": "team_instances_event_id_events_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_first_coordinator_id_users_id_fk": {
+          "name": "team_instances_first_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "first_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_second_coordinator_id_users_id_fk": {
+          "name": "team_instances_second_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "second_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_instance_id_team_instances_id_fk": {
+          "name": "team_memberships_team_instance_id_team_instances_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_template": {
+      "name": "team_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_template_key_unique": {
+          "name": "team_template_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_music_skills": {
+          "name": "has_music_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_acting_skills": {
+          "name": "has_acting_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dancing_skills": {
+          "name": "has_dancing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_singing_skills": {
+          "name": "has_singing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_manual_skills": {
+          "name": "has_manual_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_cooking_skills": {
+          "name": "has_cooking_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_communication_skills": {
+          "name": "has_communication_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.subscription_availability": {
+      "name": "subscription_availability",
+      "schema": "public",
+      "values": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "received",
+        "completed",
+        "waiting_list"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/core/database/migrations/meta/_journal.json
+++ b/api/src/core/database/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1750712235982,
       "tag": "0002_typical_zaladane",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1750952779103,
+      "tag": "0003_mute_may_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/core/database/schemas/team-templates.ts
+++ b/api/src/core/database/schemas/team-templates.ts
@@ -4,7 +4,7 @@ export const teamTemplates = pgTable('team_template', {
   id: uuid('id').defaultRandom().primaryKey(),
   name: text('name').notNull(),
   description: text('description'),
-  key: text('key').notNull(),
+  key: text('key').notNull().unique(),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 })

--- a/api/src/features/team/application/TeamTemplates.ts
+++ b/api/src/features/team/application/TeamTemplates.ts
@@ -1,23 +1,32 @@
+import type { TeamRepository } from '../domain/TeamRepository.ts'
 import { teamRepository } from '../repository/DrizzleTeamRepository.ts'
 
 class TeamTemplates {
+  #teamRepository: TeamRepository
+
+  constructor(teamRepository: TeamRepository) {
+    this.#teamRepository = teamRepository
+  }
+
   async createTeamTemplate(input: {
     description?: string
     key: string
     name: string
   }) {
-    const teamTemplate = await teamRepository.getTeamTemplateByKey(input.key)
+    const teamTemplate = await this.#teamRepository.selectTeamTemplateByKey(
+      input.key
+    )
 
     if (teamTemplate) {
       throw new Error('Team template key already in use.')
     }
 
-    const result = await teamRepository.insertTeamTemplate(input)
+    const result = await this.#teamRepository.insertTeamTemplate(input)
     return result
   }
 
-  async getTeamTemplateById(id: string) {
-    const teamTemplate = await teamRepository.getTeamTemplateById(id)
+  async findOne(id: string) {
+    const teamTemplate = await this.#teamRepository.selectTeamTemplateById(id)
 
     if (!teamTemplate) {
       return undefined
@@ -25,6 +34,11 @@ class TeamTemplates {
 
     return teamTemplate
   }
+
+  async listAll() {
+    const teamTemplates = await this.#teamRepository.listTeamTemplates()
+    return teamTemplates
+  }
 }
 
-export const teamTemplatesApp = new TeamTemplates()
+export const teamTemplatesApp = new TeamTemplates(teamRepository)

--- a/api/src/features/team/domain/TeamRepository.ts
+++ b/api/src/features/team/domain/TeamRepository.ts
@@ -1,10 +1,13 @@
-import {
+import type {
   TeamTemplateInput,
   TeamTemplateModel,
 } from '../../../core/database/schemas/index.ts'
 
 export interface TeamRepository {
   insertTeamTemplate: (input: TeamTemplateInput) => Promise<string>
-  getTeamTemplateByKey: (key: string) => Promise<TeamTemplateModel | undefined>
-  getTeamTemplateById: (id: string) => Promise<TeamTemplateModel | undefined>
+  selectTeamTemplateByKey: (
+    key: string
+  ) => Promise<TeamTemplateModel | undefined>
+  selectTeamTemplateById: (id: string) => Promise<TeamTemplateModel | undefined>
+  listTeamTemplates: () => Promise<TeamTemplateModel[]>
 }

--- a/api/src/features/team/http/team-templates-routes.ts
+++ b/api/src/features/team/http/team-templates-routes.ts
@@ -8,6 +8,7 @@ import type {
 import type { ZodTypeProvider } from 'fastify-type-provider-zod'
 import { z } from 'zod/v4'
 import { teamTemplatesApp } from '../application/TeamTemplates.ts'
+import { HttpStatus } from '../../../shared/http-statuses.ts'
 
 type FastifyServerInstance = FastifyInstance<
   RawServerDefault,
@@ -46,7 +47,7 @@ export function teamTemplateRoutes(server: FastifyServerInstance) {
         })
 
         return reply
-          .code(201)
+          .code(HttpStatus.Created)
           .header('location', `/teams/templates/${resultId}`)
           .send(resultId)
       }
@@ -61,19 +62,26 @@ export function teamTemplateRoutes(server: FastifyServerInstance) {
       },
       async (request, reply) => {
         const { teamTemplateId } = request.params
-        const teamTemplate =
-          await teamTemplatesApp.getTeamTemplateById(teamTemplateId)
+        const teamTemplate = await teamTemplatesApp.findOne(teamTemplateId)
 
         if (!teamTemplate) {
-          return reply.code(404).send({
+          return reply.code(HttpStatus.NotFound).send({
             message: 'Team template not found',
           })
         }
 
-        return reply.code(200).send({
+        return reply.code(HttpStatus.Ok).send({
           teamTemplate,
         })
       }
     )
+
+    server.get('/teams/templates', async (request, reply) => {
+      const teamTemplates = await teamTemplatesApp.listAll()
+
+      return reply.code(HttpStatus.Ok).send({
+        teamTemplates,
+      })
+    })
   }
 }

--- a/api/src/features/team/repository/DrizzleTeamRepository.ts
+++ b/api/src/features/team/repository/DrizzleTeamRepository.ts
@@ -23,7 +23,7 @@ class DrizzleTeamRepository implements TeamRepository {
     return result[0].id ?? ''
   }
 
-  async getTeamTemplateByKey(key: string) {
+  async selectTeamTemplateByKey(key: string) {
     const result = await db
       .selectDistinct()
       .from(schema.teamTemplates)
@@ -36,7 +36,7 @@ class DrizzleTeamRepository implements TeamRepository {
     return undefined
   }
 
-  async getTeamTemplateById(id: string) {
+  async selectTeamTemplateById(id: string) {
     const result = await db
       .selectDistinct()
       .from(schema.teamTemplates)
@@ -47,6 +47,15 @@ class DrizzleTeamRepository implements TeamRepository {
     }
 
     return undefined
+  }
+
+  async listTeamTemplates() {
+    const results = await db
+      .selectDistinct()
+      .from(schema.teamTemplates)
+      .orderBy(schema.teamTemplates.name)
+
+    return results
   }
 }
 

--- a/api/src/shared/http-statuses.ts
+++ b/api/src/shared/http-statuses.ts
@@ -1,0 +1,8 @@
+export const HttpStatus = {
+  Ok: 200,
+  Created: 201,
+
+  NotFound: 404,
+
+  InternalServerError: 500,
+} as const


### PR DESCRIPTION
### Overview

Resolves: #35 

Adds list all team templates endpoint.

### Solution

- Adds Team Repository to Team Templates constructor.
- Create a shared http-statuses file.
- Adds a `GET /team/templates` endpoint.
- Refactor TeamRepository method names.
- Adds `unique` constraint to `schema.teamTemplate.key`.

