### PR TITLE
feat(team-template): delete team template endpoint

### DIFF
--- a/api/src/features/team/application/TeamTemplates.ts
+++ b/api/src/features/team/application/TeamTemplates.ts
@@ -67,6 +67,11 @@ class TeamTemplates {
     const updatedTeamTemplate = await this.#teamRepository.updateTeamTemplate(id, input)
     return updatedTeamTemplate
   }
+
+  async deleteTeamTemplate(id: string) {
+    const deleted = await this.#teamRepository.deleteTeamTemplate(id)
+    return deleted
+  }
 }
 
 export const teamTemplatesApp = new TeamTemplates(teamRepository)

--- a/api/src/features/team/domain/TeamRepository.ts
+++ b/api/src/features/team/domain/TeamRepository.ts
@@ -9,4 +9,5 @@ export interface TeamRepository {
     id: string,
     input: Partial<TeamTemplateInput>
   ) => Promise<TeamTemplateModel | undefined>
+  deleteTeamTemplate: (id: string) => Promise<TeamTemplateModel>
 }

--- a/api/src/features/team/http/team-templates-routes.ts
+++ b/api/src/features/team/http/team-templates-routes.ts
@@ -111,5 +111,27 @@ export function teamTemplateRoutes(server: FastifyServerInstance) {
         })
       }
     )
+
+    server.delete(
+      '/teams/templates/:teamTemplateId',
+      {
+        schema: {
+          params: getTeamTemplateParamSchema,
+        },
+      },
+      async (request, reply) => {
+        const { teamTemplateId } = request.params
+
+        const teamTemplate = await teamTemplatesApp.deleteTeamTemplate(teamTemplateId)
+
+        if (!teamTemplate) {
+          throw new Error('Something went wrong while deleting this team template')
+        }
+
+        return reply.code(HttpStatus.Ok).send({
+          message: `${teamTemplate.name} was deleted successfuly.`,
+        })
+      }
+    )
   }
 }

--- a/api/src/features/team/repository/DrizzleTeamRepository.ts
+++ b/api/src/features/team/repository/DrizzleTeamRepository.ts
@@ -63,6 +63,15 @@ class DrizzleTeamRepository implements TeamRepository {
 
     return updatedTeamTemplate[0]
   }
+
+  async deleteTeamTemplate(id: string) {
+    const deleted = await db
+      .delete(schema.teamTemplates)
+      .where(eq(schema.teamTemplates.id, id))
+      .returning()
+
+    return deleted[0]
+  }
 }
 
 export const teamRepository = new DrizzleTeamRepository()


### PR DESCRIPTION
### Overview

Resolves: #43 

Adds `DELETE /teams/templates/:template_id` endpoint.

### Solution

- Creates a new Team Repository method to deal with deletion.
- Opt for hard delete since it won't require an easy way to recover team template data.
- Adds a new route to team templates routes.
