### PR TITLE
refactor: data validation

### DIFF
--- a/api/src/features/team/core/TeamTemplate.ts
+++ b/api/src/features/team/core/TeamTemplate.ts
@@ -1,21 +1,5 @@
-import z from 'zod/v4'
 import type { TeamRepository } from '../domain/TeamRepository.ts'
 import { AppError } from '../../../shared/AppError.ts'
-
-const updatePayloadSchema = z
-  .object({
-    description: z.string().optional(),
-    name: z.string().optional(),
-  })
-  .refine((data) => {
-    if (!data.description && !data.name) {
-      return false
-    }
-    return true
-  })
-
-type UpdateInput = z.infer<typeof updatePayloadSchema>
-
 export class TeamTemplate {
   #teamRepository: TeamRepository
 
@@ -49,15 +33,7 @@ export class TeamTemplate {
     return teamTemplates
   }
 
-  async updateTeamTemplate(id: string, input: UpdateInput) {
-    const isInputValid = updatePayloadSchema.safeParse(input).success
-
-    if (!isInputValid) {
-      throw new AppError(
-        'At least one of the following attributes needs to be present: name, description'
-      )
-    }
-
+  async updateTeamTemplate(id: string, input: { name?: string; description?: string }) {
     const teamTemplateToUpdate = await this.#teamRepository.selectTeamTemplateById(id)
 
     if (!teamTemplateToUpdate) {

--- a/api/src/features/team/http/team-instances.routes.ts
+++ b/api/src/features/team/http/team-instances.routes.ts
@@ -5,12 +5,12 @@ import { teamInstanceApp } from '../application/team.ts'
 import { HttpStatus } from '../../../shared/http-statuses.ts'
 
 const createTeamInstanceBodySchema = z.object({
-  templateKey: z.string().nonempty(),
-  eventId: z.uuid(),
+  templateKey: z.string().nonempty('must not be empty'),
+  eventId: z.uuid('required'),
 })
 
 const teamInstanceIdParamSchema = z.object({
-  teamInstanceId: z.uuid(),
+  teamInstanceId: z.uuid('must not be empty'),
 })
 
 export function teamInstanceRoutes(server: FastifyServerInstance) {

--- a/api/src/features/team/http/team-templates.routes.ts
+++ b/api/src/features/team/http/team-templates.routes.ts
@@ -5,19 +5,26 @@ import type { FastifyServerInstance } from '../../../shared/fastify.types.ts'
 import { fastifyErrorHandler } from '../../../shared/fastify-error-handler.ts'
 
 const createTeamTemplateBodySchema = z.object({
-  description: z.string().optional(),
-  key: z.string(),
-  name: z.string(),
+  description: z.string().nonempty('must not be empty').optional(),
+  key: z.string('required'),
+  name: z.string('required'),
 })
 
 const getTeamTemplateParamSchema = z.object({
-  teamTemplateId: z.uuid(),
+  teamTemplateId: z.uuid('required'),
 })
 
-const updateTeamTemplateBodySchema = z.object({
-  description: z.string().nonempty().optional(),
-  name: z.string().nonempty().optional(),
-})
+const updateTeamTemplateBodySchema = z
+  .object({
+    description: z.string().nonempty('must not be empty').optional(),
+    name: z.string().nonempty('must not be empty').optional(),
+  })
+  .refine((data) => {
+    if (!data.description && !data.name) {
+      return false
+    }
+    return true
+  }, 'at least one of the following attributes are required: name, description')
 
 export function teamTemplateRoutes(server: FastifyServerInstance) {
   return () => {

--- a/api/src/features/user/core/User.ts
+++ b/api/src/features/user/core/User.ts
@@ -1,29 +1,25 @@
-import { z } from 'zod/v4'
 import type { UserRepository } from '../domain/UserRepository.ts'
 import { AppError } from '../../../shared/AppError.ts'
 
-const createUserInputSchema = z.object({
-  authId: z.string('authId is required'),
-  name: z.string('name is required').nonempty('name must not be empty'),
-  email: z.email('email is required'),
-  picture: z.string(),
-})
-type CreateUserInputSchema = z.infer<typeof createUserInputSchema>
+type CreateUserInput = {
+  authId: string
+  name: string
+  email: string
+  picture: string
+}
 
-const updateUserInputSchema = z.object({
-  phone: z.string().nullable().optional(),
-  nickname: z.string().nullable().optional(),
-  dateOfBirth: z.string().nullable().optional(),
-  hasMusicSkills: z.boolean().optional(),
-  hasActingSkills: z.boolean().optional(),
-  hasDancingSkills: z.boolean().optional(),
-  hasSingingSkills: z.boolean().optional(),
-  hasManualSkills: z.boolean().optional(),
-  hasCookingSkills: z.boolean().optional(),
-  hasCommunicationSkills: z.boolean().optional(),
-})
-
-type UpdateUserInputSchema = z.infer<typeof updateUserInputSchema>
+type UpdateUserInput = {
+  phone?: string
+  nickname?: string
+  dateOfBirth?: string
+  hasMusicSkills?: boolean
+  hasActingSkills?: boolean
+  hasDancingSkills?: boolean
+  hasSingingSkills?: boolean
+  hasManualSkills?: boolean
+  hasCookingSkills?: boolean
+  hasCommunicationSkills?: boolean
+}
 
 export class User {
   #userRepository: UserRepository
@@ -32,13 +28,7 @@ export class User {
     this.#userRepository = userRepo
   }
 
-  async createUser(input: CreateUserInputSchema) {
-    const validatedInput = createUserInputSchema.safeParse(input)
-
-    if (!validatedInput.success) {
-      throw new AppError(validatedInput.error.message)
-    }
-
+  async createUser(input: CreateUserInput) {
     const user = await this.#userRepository.getUser(input.authId)
 
     if (user) {
@@ -54,13 +44,7 @@ export class User {
     return createdUser
   }
 
-  async updateUser(authId: string, input: UpdateUserInputSchema) {
-    const validateInput = updateUserInputSchema.safeParse(input)
-
-    if (!validateInput.success) {
-      throw new AppError(validateInput.error.message)
-    }
-
+  async updateUser(authId: string, input: UpdateUserInput) {
     const userToUpdate = await this.#userRepository.getUser(authId)
 
     if (!userToUpdate) {

--- a/api/src/features/user/http/user.routes.ts
+++ b/api/src/features/user/http/user.routes.ts
@@ -12,9 +12,9 @@ type UserInfo = {
 }
 
 const updateUserInputSchema = z.object({
-  phone: z.string().nullable().optional(),
-  nickname: z.string().nullable().optional(),
-  dateOfBirth: z.string().nullable().optional(),
+  phone: z.string().nonempty('must not be empty').optional(),
+  nickname: z.string().nonempty('must not be empty').optional(),
+  dateOfBirth: z.string().nonempty('must not be empty').optional(),
   hasMusicSkills: z.boolean().optional(),
   hasActingSkills: z.boolean().optional(),
   hasDancingSkills: z.boolean().optional(),


### PR DESCRIPTION
### Overview

Concentrates request data validation on the `http` layer.

### Solution

- Removes any zod validation from the `core` layer, relying only on types from TypeScript.
- Leaves zod usage for data validation to the `http` layer.
