### PR TITLE
feat(app): card ui

### DIFF
--- a/app/src/components/Card/Card.stories.tsx
+++ b/app/src/components/Card/Card.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Card } from './Card'
+
+const meta = {
+  title: 'UI/Card',
+  tags: ['autodocs'],
+  component: Card,
+} satisfies Meta<typeof Card>
+
+export const Primary = {
+  args: {
+    children: (
+      <div>
+        <h1 className="text-lg font-semibold mb-2">Card Example</h1>
+        <p className="text-md">Here is a card example with some content on it.</p>
+        <div className="flex gap-2 mt-4">
+          <button className="px-4 py-2 border border-red-500 text-red-500 rounded">Delete</button>
+          <button className="px-4 py-2 border border-blue-500 text-blue-500 rounded">Cancel</button>
+          <button className="px-4 py-2 border bg-blue-500 text-white rounded">Confirm</button>
+        </div>
+      </div>
+    ),
+  },
+} satisfies StoryObj
+
+export default meta

--- a/app/src/components/Card/Card.tsx
+++ b/app/src/components/Card/Card.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+type CardProps = {
+  children: ReactNode
+}
+
+export function Card(props: CardProps) {
+  return <section className="w-full bg-white px-6 py-4 shadow">{props.children}</section>
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,5 +1,4 @@
-@import "tailwindcss";
-@tailwind utilities;
+@import 'tailwindcss';
 
 :root {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -8,4 +7,3 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-


### PR DESCRIPTION
### Overview

Resolves: #79 

Adds Empty Card Section UI.

### Solution

- Adds component using tailwind.
- Adds content example of storybook.
