### PR TITLE
feat(events): list events subscriptions

### DIFF
--- a/api/src/features/subscription/domain/SubscriptionRepository.ts
+++ b/api/src/features/subscription/domain/SubscriptionRepository.ts
@@ -1,9 +1,11 @@
 import { SubscriptionInput, SubscriptionModel } from '../../../core/database/schemas/index.ts'
+import type { SubscriptionWithDetails } from './subscription.types.ts'
 
 export interface SubscriptionRepository {
   insertSubscription: (input: SubscriptionInput) => Promise<SubscriptionModel | undefined>
   getSubscription: (id: string) => Promise<SubscriptionModel | undefined>
   listSubscriptions: () => Promise<SubscriptionModel[]>
+  listSubscriptionsByEventId: (eventId: string) => Promise<SubscriptionWithDetails[]>
   getSubscriptionByUserAndEvent: (
     userId: string,
     eventId: string

--- a/api/src/features/subscription/domain/subscription.types.ts
+++ b/api/src/features/subscription/domain/subscription.types.ts
@@ -1,0 +1,11 @@
+type SubscriptionStatus = 'pending' | 'received' | 'completed' | 'waiting_list'
+
+export type SubscriptionWithDetails = {
+  id: string
+  status: SubscriptionStatus
+  teams: string[]
+  user: {
+    name: string
+    phone: string | null
+  }
+}


### PR DESCRIPTION
### Overview

Resolves: #113

Adds list event subscriptions as an endpoint to the API.

### Solution

Creates a new `GET /events/:event_id/subscriptions` endpoint to retrieve all the subscriptions for a specific event. This endpoint includes the ability to:
- Query by `name`.
- Query by `teamKeys`, which supports multiple comma separated values, like `?teamKeys=teamA,teamB,teamC`.

It also supports pagination via querystring with the `page` and `size` parameters:
- `size` default value is `1`.
- `size` default value is `10`.

It adds a `SubscriptionRepository.listSubscriptionsByEventId` method to provide the necessary data for this endpoint response.

_Note: filtering and pagination are made in memory on the `Events` core class._
