### PR TITLE
feat(control-panel): team management on control panel

### DIFF
--- a/api/src/core/database/migrations/0020_abandoned_husk.sql
+++ b/api/src/core/database/migrations/0020_abandoned_husk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN "deleted_at" timestamp;

--- a/api/src/core/database/migrations/meta/0020_snapshot.json
+++ b/api/src/core/database/migrations/meta/0020_snapshot.json
@@ -1,0 +1,663 @@
+{
+  "id": "939411df-ed28-4bad-b0cd-ada0305f04fa",
+  "prevId": "65c4c18a-39d6-48a2-87db-74fbb16cde25",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_options": {
+      "name": "subscription_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_options_subscription_id_subscriptions_id_fk": {
+          "name": "subscription_options_subscription_id_subscriptions_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscription_options_team_instance_id_team_instances_id_fk": {
+          "name": "subscription_options_team_instance_id_team_instances_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "subscription_availability[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscriptions_event_id_events_id_fk": {
+          "name": "subscriptions_event_id_events_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_instances": {
+      "name": "team_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_coordinator_id": {
+          "name": "first_coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_coordinator_id": {
+          "name": "second_coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_instances_template_id_team_templates_id_fk": {
+          "name": "team_instances_template_id_team_templates_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "team_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_event_id_events_id_fk": {
+          "name": "team_instances_event_id_events_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_first_coordinator_id_users_id_fk": {
+          "name": "team_instances_first_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "first_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_second_coordinator_id_users_id_fk": {
+          "name": "team_instances_second_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "second_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_instance_id_team_instances_id_fk": {
+          "name": "team_memberships_team_instance_id_team_instances_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_templates": {
+      "name": "team_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_templates_key_unique": {
+          "name": "team_templates_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_acting_skills": {
+          "name": "has_acting_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_communication_skills": {
+          "name": "has_communication_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_cooking_skills": {
+          "name": "has_cooking_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dancing_skills": {
+          "name": "has_dancing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_manual_skills": {
+          "name": "has_manual_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_music_skills": {
+          "name": "has_music_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_singing_skills": {
+          "name": "has_singing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experience_type": {
+          "name": "experience_type",
+          "type": "experience_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'experienced'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.subscription_availability": {
+      "name": "subscription_availability",
+      "schema": "public",
+      "values": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "received",
+        "completed",
+        "waiting_list"
+      ]
+    },
+    "public.experience_type": {
+      "name": "experience_type",
+      "schema": "public",
+      "values": [
+        "newbie",
+        "experienced",
+        "coordinator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/core/database/migrations/meta/_journal.json
+++ b/api/src/core/database/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1753830877503,
       "tag": "0019_normal_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1756242380562,
+      "tag": "0020_abandoned_husk",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/core/database/schemas/events.ts
+++ b/api/src/core/database/schemas/events.ts
@@ -6,4 +6,5 @@ export const events = pgTable('events', {
   description: text('description').notNull(),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at'),
 })

--- a/api/src/features/control-panel/application/control-panel.ts
+++ b/api/src/features/control-panel/application/control-panel.ts
@@ -1,4 +1,10 @@
+import { eventRepository } from '../../event/repository/DrizzleEventRepository.ts'
+import { teamInstanceRepository } from '../../team/repository/DrizzleTeamInstanceRepository.ts'
 import { teamTemplateRepository } from '../../team/repository/DrizzleTeamTemplateRepository.ts'
 import { ControlPanel } from '../core/ControlPanel.ts'
 
-export const controlPanelApp = new ControlPanel(teamTemplateRepository)
+export const controlPanelApp = new ControlPanel(
+  teamTemplateRepository,
+  eventRepository,
+  teamInstanceRepository
+)

--- a/api/src/features/control-panel/core/ControlPanel.ts
+++ b/api/src/features/control-panel/core/ControlPanel.ts
@@ -1,11 +1,21 @@
 import { AppError } from '../../../shared/AppError.ts'
+import type { EventRepository } from '../../event/domain/EventRepository.ts'
+import type { TeamInstanceRepository } from '../../team/domain/TeamInstanceRepository.ts'
 import type { TeamTemplateRepository } from '../../team/domain/TeamTemplateRepository.ts'
 
 export class ControlPanel {
   #teamTemplateRepository: TeamTemplateRepository
+  #eventRepository: EventRepository
+  #teamInstanceRepository: TeamInstanceRepository
 
-  constructor(teamTemplateRepo: TeamTemplateRepository) {
+  constructor(
+    teamTemplateRepo: TeamTemplateRepository,
+    eventRepo: EventRepository,
+    teamInstanceRepo: TeamInstanceRepository
+  ) {
     this.#teamTemplateRepository = teamTemplateRepo
+    this.#eventRepository = eventRepo
+    this.#teamInstanceRepository = teamInstanceRepo
   }
 
   async createTeamTemplate(input: { description?: string; key: string; name: string }) {
@@ -53,5 +63,53 @@ export class ControlPanel {
   async deleteTeamTemplate(id: string) {
     const deleted = await this.#teamTemplateRepository.deleteTeamTemplate(id)
     return deleted
+  }
+
+  async listEvents() {
+    const events = await this.#eventRepository.findAllEvents()
+    return events
+  }
+
+  async getEvent(eventId: string) {
+    const event = await this.#eventRepository.findEvent(eventId)
+
+    if (!event) {
+      throw new AppError('Event not found')
+    }
+
+    return event
+  }
+
+  async createEvent(input: { name: string; description: string }) {
+    const createdEvent = await this.#eventRepository.insertEvent(input)
+    await this.#createEventTeams(createdEvent.id)
+
+    return createdEvent
+  }
+
+  async #createEventTeams(eventId: string) {
+    const teamTemplates = await this.#teamTemplateRepository.listTeamTemplates()
+    const templateIds = teamTemplates.map((template) => template.id)
+    const teamInstances = await this.#teamInstanceRepository.bulkInsertTeamInstances(
+      eventId,
+      templateIds
+    )
+
+    return teamInstances
+  }
+
+  async updateEvent(id: string, input: { name?: string; description?: string }) {
+    const eventToUpdate = await this.#eventRepository.findEvent(id)
+    if (!eventToUpdate) {
+      throw new AppError('Event not found, please check the event id.')
+    }
+
+    const updatedEvent = await this.#eventRepository.updateEvent(id, input)
+    return updatedEvent
+  }
+
+  async deleteEvent(id: string) {
+    const deletedEvent = await this.#eventRepository.softDeleteEvent(id)
+    return deletedEvent
   }
 }

--- a/api/src/features/event/application/events-app.ts
+++ b/api/src/features/event/application/events-app.ts
@@ -1,14 +1,10 @@
 import { Events } from '../core/Events.ts'
-import { eventRepository } from '../repository/DrizzleEventRepository.ts'
-import { teamTemplateRepository } from '../../team/repository/DrizzleTeamTemplateRepository.ts'
 import { teamInstanceRepository } from '../../team/repository/DrizzleTeamInstanceRepository.ts'
 import { subscriptionRepository } from '../../subscription/repository/DrizzleSubscriptionRepository.ts'
 import { subscriptionOptionRepository } from '../../subscription/repository/DrizzleSubscriptionOptionRepository.ts'
 import { userRepository } from '../../user/repository/DrizzleUserRepository.ts'
 
 export const eventsApp = new Events(
-  eventRepository,
-  teamTemplateRepository,
   teamInstanceRepository,
   subscriptionRepository,
   subscriptionOptionRepository,

--- a/api/src/features/event/domain/EventRepository.ts
+++ b/api/src/features/event/domain/EventRepository.ts
@@ -4,6 +4,6 @@ export interface EventRepository {
   insertEvent: (input: EventInput) => Promise<EventModel>
   findEvent: (id: string) => Promise<EventInput | undefined>
   findAllEvents: () => Promise<EventModel[]>
-  deleteEvent: (id: string) => Promise<EventModel>
+  softDeleteEvent: (id: string) => Promise<EventModel>
   updateEvent: (id: string, input: Partial<EventInput>) => Promise<EventModel>
 }

--- a/api/src/features/event/http/events.routes.ts
+++ b/api/src/features/event/http/events.routes.ts
@@ -10,15 +10,6 @@ const eventIdParamSchema = z.object({
   eventId: z.uuid(),
 })
 
-const createEventBodySchema = z.object({
-  name: z.string('required').nonempty(),
-  description: z.string('required').nonempty(),
-})
-
-const updateEventBodySchema = createEventBodySchema.partial().refine((data) => {
-  return data.name || data.description
-}, 'At least one of the following attributes needs to be present: name, description')
-
 const subscriptionAvailabilityEnum = z.enum([
   'monday',
   'tuesday',
@@ -72,77 +63,6 @@ const listSubscriptionsQuerystringSchema = z.object({
 
 export function eventsRoutes(server: FastifyServerInstance) {
   return () => {
-    server.get('/events', {}, async (_, reply) => {
-      try {
-        const events = await eventsApp.listEvents()
-
-        return reply.code(HttpStatus.Ok).send({
-          events,
-        })
-      } catch (error) {
-        fastifyErrorHandler(reply, error)
-      }
-    })
-
-    server.get(
-      '/events/:eventId',
-      {
-        schema: {
-          params: eventIdParamSchema,
-        },
-      },
-      async (request, reply) => {
-        try {
-          const { eventId } = request.params
-          const event = await eventsApp.getEvent(eventId)
-
-          return reply.code(HttpStatus.Ok).send(event)
-        } catch (error) {
-          fastifyErrorHandler(reply, error)
-        }
-      }
-    )
-
-    server.post('/events', { schema: { body: createEventBodySchema } }, async (request, reply) => {
-      try {
-        const event = await eventsApp.createEvent(request.body)
-
-        return reply.code(HttpStatus.Ok).header('location', `/events/${event.id}`).send({ event })
-      } catch (error) {
-        fastifyErrorHandler(reply, error)
-      }
-    })
-
-    server.patch(
-      '/events/:eventId',
-      { schema: { params: eventIdParamSchema, body: updateEventBodySchema } },
-      async (request, reply) => {
-        try {
-          const { eventId } = request.params
-          const event = await eventsApp.updateEvent(eventId, request.body)
-
-          return reply.code(HttpStatus.Ok).send({ event })
-        } catch (error) {
-          fastifyErrorHandler(reply, error)
-        }
-      }
-    )
-
-    server.delete(
-      '/events/:eventId',
-      { schema: { params: eventIdParamSchema } },
-      async (request, reply) => {
-        try {
-          const { eventId } = request.params
-          const event = await eventsApp.deleteEvent(eventId)
-
-          return reply.code(HttpStatus.Ok).send({ message: `${event.name} deleted successfuly.` })
-        } catch (error) {
-          fastifyErrorHandler(reply, error)
-        }
-      }
-    )
-
     server.post(
       '/events/:eventId/subscribe',
       {


### PR DESCRIPTION
### Overview

Adds team management to the Control Panel Core Class on the API.

### Solution

- Moves the CRUD methods and routes from Events to Control Panel.
- Adapts `controlPanelApp.deleteEvent` to be a soft delete instead of hard delete.
- Adds `deleted_at` column to event table.
