### PR TITLE
feat(events): get current event api

### DIFF
--- a/api/src/features/control-panel/core/ControlPanel.ts
+++ b/api/src/features/control-panel/core/ControlPanel.ts
@@ -7,6 +7,7 @@ export class ControlPanel {
   #teamTemplateRepository: TeamTemplateRepository
   #eventRepository: EventRepository
   #teamInstanceRepository: TeamInstanceRepository
+  currentEventId: string | null = null
 
   constructor(
     teamTemplateRepo: TeamTemplateRepository,
@@ -119,13 +120,19 @@ export class ControlPanel {
       throw new AppError('Event not found, please check the event id.')
     }
 
-    const updatedEvent = this.#eventRepository.updateEvent(eventId, {
+    if (eventToUpdate.id === this.currentEventId) {
+      return eventToUpdate
+    }
+
+    const updatedEvent = await this.#eventRepository.updateEvent(eventId, {
       isCurrent: true,
     })
 
     await this.#eventRepository.bulkUpdateEvents(eventId, {
       isCurrent: false,
     })
+
+    this.currentEventId = updatedEvent.id
 
     return updatedEvent
   }

--- a/api/src/features/event/application/events-app.ts
+++ b/api/src/features/event/application/events-app.ts
@@ -3,10 +3,12 @@ import { teamInstanceRepository } from '../../team/repository/DrizzleTeamInstanc
 import { subscriptionRepository } from '../../subscription/repository/DrizzleSubscriptionRepository.ts'
 import { subscriptionOptionRepository } from '../../subscription/repository/DrizzleSubscriptionOptionRepository.ts'
 import { userRepository } from '../../user/repository/DrizzleUserRepository.ts'
+import { eventRepository } from '../repository/DrizzleEventRepository.ts'
 
 export const eventsApp = new Events(
   teamInstanceRepository,
   subscriptionRepository,
   subscriptionOptionRepository,
-  userRepository
+  userRepository,
+  eventRepository
 )

--- a/api/src/features/event/core/Events.ts
+++ b/api/src/features/event/core/Events.ts
@@ -5,6 +5,7 @@ import type { UserRepository } from '../../user/domain/UserRepository.ts'
 import type { SubscriptionRepository } from '../../subscription/domain/SubscriptionRepository.ts'
 import type { SubscriptionPayload } from '../domain/subscription-types.ts'
 import type { SubscriptionWithDetails } from '../../subscription/domain/subscription.types.ts'
+import type { EventRepository } from '../domain/EventRepository.ts'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_SIZE = 10
@@ -14,17 +15,20 @@ export class Events {
   #subscriptionRepository: SubscriptionRepository
   #subscriptionOptionRepository: SubscriptionOptionRepository
   #userRepository: UserRepository
+  #eventsRepository: EventRepository
 
   constructor(
     teamInstanceRepo: TeamInstanceRepository,
     subscriptionRepo: SubscriptionRepository,
     subscriptionOptionRepo: SubscriptionOptionRepository,
-    userRepo: UserRepository
+    userRepo: UserRepository,
+    eventRepo: EventRepository
   ) {
     this.#teamInstanceRepository = teamInstanceRepo
     this.#subscriptionRepository = subscriptionRepo
     this.#subscriptionOptionRepository = subscriptionOptionRepo
     this.#userRepository = userRepo
+    this.#eventsRepository = eventRepo
   }
 
   async subscribe(eventId: string, userAuthId: string, input: SubscriptionPayload) {
@@ -115,6 +119,16 @@ export class Events {
     )
 
     return this.#formatSubscriptions(teams, filteredSubscriptions)
+  }
+
+  async getCurrentEvent() {
+    const currentEvent = await this.#eventsRepository.findCurrentEvent()
+
+    if (!currentEvent) {
+      throw new AppError('Current event not set')
+    }
+
+    return currentEvent
   }
 
   #defineExperienceType(isNewbie?: boolean, hasCoordinatorExperience?: boolean) {

--- a/api/src/features/event/domain/EventRepository.ts
+++ b/api/src/features/event/domain/EventRepository.ts
@@ -7,4 +7,5 @@ export interface EventRepository {
   softDeleteEvent: (id: string) => Promise<EventModel>
   updateEvent: (id: string, input: Partial<EventInput>) => Promise<EventModel>
   bulkUpdateEvents: (id: string, input: Partial<EventInput>) => Promise<EventModel[]>
+  findCurrentEvent: () => Promise<EventModel | undefined>
 }

--- a/api/src/features/event/http/events.routes.ts
+++ b/api/src/features/event/http/events.routes.ts
@@ -122,5 +122,15 @@ export function eventsRoutes(server: FastifyServerInstance) {
         }
       }
     )
+
+    server.get('/events/current', async (__dirname, reply) => {
+      try {
+        const currentEvent = await eventsApp.getCurrentEvent()
+
+        return reply.code(HttpStatus.Ok).send({ currentEvent })
+      } catch (error) {
+        fastifyErrorHandler(reply, error)
+      }
+    })
   }
 }

--- a/api/src/features/event/repository/DrizzleEventRepository.ts
+++ b/api/src/features/event/repository/DrizzleEventRepository.ts
@@ -49,6 +49,15 @@ class DrizzleEventRepository implements EventRepository {
 
     return updatedEvents
   }
+
+  async findCurrentEvent() {
+    const currentEvent = await db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.isCurrent, true))
+
+    return currentEvent[0]
+  }
 }
 
 export const eventRepository = new DrizzleEventRepository()


### PR DESCRIPTION
### Overview

Implements `Events.getCurrentEvent` method.

### Solution

Creates a method to get the current event so the id can be used to subscribe and assign to a team. In the future this endpoint may be removed to deal with current event in the backend side.
