### PR TITLE
feat(app): subscription summary box ui

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.60.0",
+        "react-icons": "^5.5.0",
         "react-router": "^7.6.3",
         "tailwindcss": "^4.1.11",
         "zod": "^4.0.5"
@@ -5169,6 +5170,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",
+    "react-icons": "^5.5.0",
     "react-router": "^7.6.3",
     "tailwindcss": "^4.1.11",
     "zod": "^4.0.5"

--- a/app/src/components/SubscriptionSummaryBox/SubscriptionSummaryBox.tsx
+++ b/app/src/components/SubscriptionSummaryBox/SubscriptionSummaryBox.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react'
+import { FiUsers, FiClock, FiCheck } from 'react-icons/fi'
+
+type SummaryBoxProps = {
+  title: string
+  value: string | number
+  description?: string
+  icon?: ReactNode
+  variant?: 'total' | 'approved' | 'pending'
+}
+
+const variantStyles = {
+  total: {
+    iconBg: 'bg-blue-100',
+    iconColor: 'text-blue-600',
+    defaultIcon: <FiUsers size="20px" />,
+  },
+  approved: {
+    iconBg: 'bg-green-100',
+    iconColor: 'text-green-600',
+    defaultIcon: <FiCheck size="20px" />,
+  },
+  pending: {
+    iconBg: 'bg-yellow-100',
+    iconColor: 'text-yellow-600',
+    defaultIcon: <FiClock size="20px" />,
+  },
+}
+
+export function SubscriptionSummaryBox(props: SummaryBoxProps) {
+  const variant = props.variant || 'total'
+  const variantConfig = variantStyles[variant]
+
+  return (
+    <div className="p-6 border border-gray-200 rounded-lg shadow-sm bg-white flex items-center gap-4">
+      <figure className={`flex items-center justify-center p-2 rounded-lg ${variantConfig.iconBg}`}>
+        <div className={variantConfig.iconColor}>{props.icon || variantConfig.defaultIcon}</div>
+      </figure>
+      <div className="flex flex-col">
+        <label className="text-xs text-gray-500">{props.title}</label>
+        <span className="text-2xl font-bold text-gray-900">{props.value}</span>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/SubscriptionSummaryBox/SummaryBox.stories.tsx
+++ b/app/src/components/SubscriptionSummaryBox/SummaryBox.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { SubscriptionSummaryBox } from './SubscriptionSummaryBox'
+
+const meta = {
+  title: 'UI/SubscriptionSummaryBox',
+  component: SubscriptionSummaryBox,
+  tags: ['autodocs'],
+} satisfies Meta<typeof SubscriptionSummaryBox>
+
+export const Total = {
+  args: {
+    title: 'Total Subscriptions',
+    value: '3',
+    variant: 'total',
+  },
+} satisfies StoryObj<typeof SubscriptionSummaryBox>
+
+export const Pending = {
+  args: {
+    title: 'Pending Review',
+    value: '2',
+    variant: 'pending',
+  },
+} satisfies StoryObj<typeof SubscriptionSummaryBox>
+
+export const Approved = {
+  args: {
+    title: 'Approved',
+    value: '1',
+    variant: 'approved',
+  },
+} satisfies StoryObj<typeof SubscriptionSummaryBox>
+
+export default meta


### PR DESCRIPTION
### Overview

Resolves: #87

This pull request introduces a new reusable UI component for displaying subscription summary information, along with its Storybook stories for documentation and testing. It also adds the `react-icons` dependency to the project to support icon usage in the new component.

### Solution

**Component Addition:**

* Added the new `SubscriptionSummaryBox` component in `SubscriptionSummaryBox.tsx`, which displays a summary box with a title, value, description, and a variant-specific icon and styling. Icons from `react-icons` are used for visual representation of different summary types.

**Storybook Documentation:**

* Created `SummaryBox.stories.tsx` with Storybook stories for the `SubscriptionSummaryBox` component, covering the "total", "pending", and "approved" variants to aid in documentation and visual testing.

**Dependency Management:**

* Added `react-icons` as a dependency in both `package.json` and `package-lock.json` to enable usage of icon components in the UI. [[1]](diffhunk://#diff-012b982f97a0d326aeec58dd3b789484b05a944d609afe1b8ed5e299fc485f61R21) [[2]](diffhunk://#diff-baa935e47c548c1c2375e84a25203d60d0c81efae59289e5f5f5bdf7a4047c9aR17) [[3]](diffhunk://#diff-baa935e47c548c1c2375e84a25203d60d0c81efae59289e5f5f5bdf7a4047c9aR5175-R5183)
