### PR TITLE
feat(app): teambox ui

### DIFF
--- a/app/src/components/TeamBox/TeamBox.stories.tsx
+++ b/app/src/components/TeamBox/TeamBox.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, userEvent, within } from 'storybook/internal/test'
+import { TeamBox } from './TeamBox'
+
+const meta = {
+  title: 'UI/TeamBox',
+  component: TeamBox,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    onToggle: { action: 'changed' },
+  },
+} satisfies Meta<typeof TeamBox>
+
+export default meta
+
+export const Default = {
+  args: {
+    title: 'Eagles',
+    description: 'Soaring high with keen vision and precision',
+  },
+} satisfies StoryObj<typeof TeamBox>
+
+export const Selected = {
+  args: {
+    title: 'Eagles',
+    description: 'Soaring high with keen vision and precision',
+    defaultSelected: false,
+    onToggle: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const button = canvas.getByRole('checkbox')
+    await userEvent.click(button)
+    expect(args.onToggle).toHaveBeenCalledWith(true)
+  },
+} satisfies StoryObj<typeof TeamBox>
+
+export const Disabled = {
+  args: {
+    title: 'Eagles',
+    description: 'Soaring high with keen vision and precision',
+    disabled: true,
+  },
+} satisfies StoryObj<typeof TeamBox>

--- a/app/src/components/TeamBox/TeamBox.tsx
+++ b/app/src/components/TeamBox/TeamBox.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react'
+
+export type TeamBoxProps = {
+  /** Team name */
+  title: string
+  /** Team description */
+  description?: string
+  /** Controlled selected state */
+  selected?: boolean
+  /** Uncontrolled initial selected state */
+  defaultSelected?: boolean
+  /** Disable interaction and apply muted styles */
+  disabled?: boolean
+  /** Callback when selection toggles */
+  onToggle?: (selected?: boolean) => void
+}
+
+function generateRandomPastelColor() {
+  const hue = Math.floor(Math.random() * 360)
+  const saturation = 70
+  const lightness = 60
+  return `hsl(${hue} ${saturation}% ${lightness}%)`
+}
+
+export function TeamBox(props: TeamBoxProps) {
+  const [internalSelected, setInternalSelected] = useState<boolean>(props.defaultSelected ?? false)
+  const isSelected = props.selected ?? internalSelected
+  const dotColor = useMemo(() => generateRandomPastelColor(), [])
+
+  const handleClick = () => {
+    setInternalSelected((prevState) => {
+      const newState = !prevState
+      props.onToggle?.(newState)
+      return newState
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      onClick={handleClick}
+      disabled={props.disabled}
+      value="test"
+      className={[
+        'w-full flex items-start gap-3 rounded-md bg-white p-4 text-left shadow border transition-colors cursor-pointer',
+        'disabled:opacity-60 disabled:cursor-not-allowed',
+        isSelected ? 'border-blue-500' : 'border-gray-200 hover:border-gray-300',
+      ].join(' ')}
+    >
+      <span
+        aria-hidden
+        className="mt-1 h-3 w-3 rounded-full flex-shrink-0"
+        style={{ backgroundColor: dotColor }}
+      />
+      <span className="flex flex-col">
+        <span className="text-sm font-semibold text-gray-900">{props.title}</span>
+        {props.description && <span className="text-xs text-gray-500">{props.description}</span>}
+      </span>
+    </button>
+  )
+}


### PR DESCRIPTION
### Overview

Resolves: #85 

This pull request introduces a new `TeamBox` UI component along with its Storybook stories for interactive testing and documentation. The most important changes are grouped below:

### Solution

* Added the `TeamBox` component in `TeamBox.tsx`, supporting controlled and uncontrolled selection, disabled state, and a callback for selection changes. It also features a randomly colored pastel dot for visual distinction.

* Created `TeamBox.stories.tsx` with multiple stories (`Default`, `Selected`, `Disabled`) to showcase the component's behavior, including an interactive test for selection toggling.
