### PR TITLE
docs: update claude docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,35 +1,15 @@
-# Copilot Instructions
-
 ## Project Overview
 
 EJC Hub - A event management application for managing events, teams, subscriptions, and users.
 
 ## Tech Stack
 
-### API (`/api`)
-
-- **Runtime:** Node.js with TypeScript
-- **Framework:** Fastify with `fastify-type-provider-zod`
-- **ORM:** Drizzle ORM with PostgreSQL
-- **Authentication:** Auth0 (`@auth0/auth0-fastify-api`)
-- **Validation:** Zod
-- **Package Manager:** npm
-
-### App (`/app`)
-
-- **Framework:** React with TypeScript
-- **Build Tool:** Vite
-- **Styling:** Tailwind CSS
-- **Storybook:** For component documentation
-- **Testing:** Vitest
-- **Linting:** ESLint with Prettier
-- **Authentication:** Auth0
-
-### Common (`/common`)
-
-- **Shared:** TypeScript utilities and types
-- **Permissions:** Permission helpers shared between API and App
-- **Testing:** Jest
+- API (`/api`) - Node.js with TypeScript
+- App (`/app`) - React with TypeScript
+- Common (`/common`)
+  - **Shared:** TypeScript utilities and types
+  - **Permissions:** Permission helpers shared between API and App
+  - **Testing:** Jest
 
 ## Project Structure
 
@@ -66,40 +46,6 @@ EJC Hub - A event management application for managing events, teams, subscriptio
 - Keep functions small and focused
 - Use `type` over `interface` for type definitions unless extending
 
-### API File Naming
-
-- Routes: `*.routes.ts`
-- Repositories: `*.repository.ts`
-- Schemas: `*.schema.ts`
-
-### App File Naming
-
-- Components: `ComponentName/ComponentName.tsx`
-- Stories: `ComponentName/ComponentName.stories.tsx`
-- Hooks: `useHookName.ts` or `useHookName/useHookName.ts`
-- Pages: `PageName.tsx`
-
-### Fastify Patterns (API)
-
-- Use `withTypeProvider<ZodTypeProvider>()` for type-safe routes
-- Register routes using `server.register()`
-- Use `server.authenticate` preHandler for protected routes
-- Use Zod for request/response validation
-
-### React Patterns (App)
-
-- Use functional components with hooks
-- Create Storybook stories for all reusable components
-- Use custom hooks for reusable logic
-- Keep components small and focused
-- Do not destructure props in the function signature, use `props.propName` instead unless it needs a default value
-
-### Database (API)
-
-- Use Drizzle ORM for database operations
-- Repositories handle all database access
-- Use cases orchestrate business logic
-
 ### Permissions (Common)
 
 - Use `hasPermission()` for single permission checks
@@ -108,8 +54,4 @@ EJC Hub - A event management application for managing events, teams, subscriptio
 
 ## Testing
 
-- API: Unit tests for use cases
-- App: Vitest for component and hook tests
-- Common: Jest for utility tests
 - Use descriptive test names
-- Write stories for visual component testing

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,47 @@
+## Project Overview
+
+The NodeJS Fastify API that supports EJC Hub - A event management application for managing events, teams, subscriptions, and users.
+
+For feature details read the ./docs/features.md file.
+
+## Architecture
+
+For architecture details read the ./docs/architecture.md file.
+
+## Tech Stack
+
+- **Runtime:** Node.js with TypeScript
+- **Framework:** Fastify with `fastify-type-provider-zod`
+- **ORM:** Drizzle ORM with PostgreSQL
+- **Authentication:** Auth0 (`@auth0/auth0-fastify-api`)
+- **Validation:** Zod
+- **Package Manager:** npm
+
+## Code Conventions
+
+### File Naming
+
+- Routes: `*.routes.ts`
+- Repositories: `*.repository.ts`
+- Schemas: `*.schema.ts`
+
+### Fastify Patterns
+
+- Use `withTypeProvider<ZodTypeProvider>()` for type-safe routes
+- Register routes using `server.register()`
+- Use `server.authenticate` preHandler for protected routes
+- Use Zod for request/response validation
+
+For Authentication and Authorization details read the ./docs/auth.md file.
+
+### Database
+
+- Use Drizzle ORM for database operations
+- Repositories handle all database access
+- Use cases orchestrate business logic
+
+For database schema details read the ./docs/database-schema.md file.
+
+## Testing
+
+- API: Unit tests for use cases

--- a/api/docs/architecture.md
+++ b/api/docs/architecture.md
@@ -1,0 +1,105 @@
+# API Architecture
+
+## Overview
+
+Node.js API built with **Fastify**, **Drizzle ORM** (PostgreSQL), and **Auth0** for authentication. The codebase follows a **Clean Architecture** pattern with clear separation between domain logic, data access, and HTTP handling.
+
+## Folder Structure
+
+```
+api/src/
+├── core/
+│   ├── database/
+│   │   ├── client.ts              # Drizzle ORM connection setup
+│   │   ├── migrations/            # SQL migration files
+│   │   └── schemas/               # Drizzle table definitions
+│   │       ├── events.ts
+│   │       ├── subscriptions.ts
+│   │       ├── subscription-options.ts
+│   │       ├── team-instances.ts
+│   │       ├── team-memberships.ts
+│   │       ├── team-templates.ts
+│   │       ├── users.ts
+│   │       └── index.ts
+│   └── envs/
+│       └── env.ts                 # Environment variables (PORT, DATABASE_URL, AUTH_*)
+│
+├── features/
+│   ├── control-panel/             # Admin operations (events & team templates CRUD)
+│   ├── event/                     # Event subscriptions, team listing, current event
+│   ├── subscription/              # Subscription queries
+│   ├── team/                      # Team management and memberships
+│   └── user/                      # User sync and profile updates
+│
+├── shared/
+│   ├── AppError.ts                # Custom business logic error class
+│   ├── extract-user-info-from-token.ts  # JWT token decoder
+│   ├── fastify-auth-guard.ts      # Authentication middleware
+│   ├── fastify-error-handler.ts   # Global error handler
+│   ├── fastify-require-permission.ts    # Authorization middleware
+│   ├── fastify.types.ts           # Typed Fastify instance
+│   └── http-statuses.ts           # HTTP status code constants
+│
+└── server.ts                      # Entry point: Fastify init, plugin registration, route binding
+```
+
+## Architecture Layers
+
+Each feature module follows a consistent layered structure:
+
+```
+feature/
+├── domain/          # Repository interfaces (contracts)
+├── core/            # Business logic classes
+├── repository/      # Drizzle ORM implementations of domain interfaces
+├── application/     # Wiring layer — instantiates core classes with concrete repositories
+└── http/            # Route definitions, request/response Zod schemas
+```
+
+**Domain** — Defines repository interfaces that describe what data operations are available, without specifying how they are implemented.
+
+**Core** — Contains business logic classes that depend only on domain interfaces. This is where validation rules, orchestration, and domain-specific decisions live.
+
+**Repository** — Drizzle ORM implementations of the domain interfaces. All database queries and mutations happen here.
+
+**Application** — Instantiates the core class with concrete repository implementations, exporting a ready-to-use singleton.
+
+**HTTP** — Fastify route handlers that parse requests (using Zod schemas), call into the application layer, and return responses.
+
+## Core Infrastructure
+
+### Database
+
+- **ORM:** Drizzle ORM with `node-postgres` driver
+- **Connection:** Configured via `DATABASE_URL` environment variable
+- **Casing:** Snake-case column mapping (`casing: 'snake_case'`)
+- **Migrations:** Sequential SQL files in `core/database/migrations/`
+
+### Environment
+
+Validated variables:
+
+- `PORT` — Server port (default: `3333`)
+- `DATABASE_URL` — PostgreSQL connection string
+- `AUTH_DOMAIN` — Auth0 tenant domain
+- `AUTH_AUDIENCE` — Auth0 API audience identifier
+
+## Shared Utilities
+
+| Utility                        | Purpose                                                                                             |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `AppError`                     | Custom error class for business logic exceptions                                                    |
+| `fastify-auth-guard`           | Pre-handler that enforces authentication via `server.requireAuth()` with optional permission checks |
+| `fastify-require-permission`   | Pre-handler that verifies JWT permissions (supports `all` or `any` mode)                            |
+| `fastify-error-handler`        | Maps `AppError` to 422 responses; unhandled errors to 500                                           |
+| `extract-user-info-from-token` | Decodes Auth0 JWT to extract `authId`, `email`, `name`, `picture`, and `permissions`                |
+| `http-statuses`                | Constants for HTTP status codes (200, 201, 401, 403, 404, 422, 500)                                 |
+| `fastify.types`                | Typed `FastifyServerInstance` with `ZodTypeProvider`                                                |
+
+## Design Patterns
+
+- **Clean Architecture** — Domain interfaces → Core business logic → Repository persistence → HTTP transport. Each layer depends only on the layer above it.
+- **Repository Pattern** — All database access is abstracted behind interfaces, making it easy to test core logic in isolation.
+- **Dependency Injection** — Core classes receive repository interfaces via constructor; the application layer wires concrete implementations.
+- **Type-safe Validation** — Zod schemas validate all incoming requests through Fastify's `ZodTypeProvider`, ensuring runtime and compile-time safety.
+- **Soft Deletes** — Events use a `deleted_at` timestamp instead of hard deletes.

--- a/api/docs/auth.md
+++ b/api/docs/auth.md
@@ -1,0 +1,19 @@
+## Authentication & Authorization
+
+1. **Authentication** — Auth0 plugin validates the JWT bearer token on every protected route. The `authGuard` pre-handler enforces token presence via `server.requireAuth()`.
+
+2. **Token extraction** — The JWT is decoded to extract the user's `authId`, `email`, `name`, `picture`, and `permissions` array.
+
+3. **Authorization** — The `fastifyRequirePermission` pre-handler checks if the token's permissions include the required values. Supports two modes:
+
+   - `all` — user must have every listed permission
+   - `any` — user must have at least one listed permission
+
+   Returns **403 Forbidden** if the check fails.
+
+4. **Permission types** (defined in `common/permissions`):
+   - `EventPermissions` — Read, Create, Update, Delete
+   - `SubscriptionPermissions` — Read, Create
+   - `TeamInstancePermissions` — Read, Update
+   - `TeamMembershipPermissions` — Create, Delete
+   - `TeamTemplatePermissions` — Read, Create, Update, Delete

--- a/api/docs/database-schema.md
+++ b/api/docs/database-schema.md
@@ -1,0 +1,87 @@
+## Database Schema
+
+### Tables
+
+**users**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| auth_id | text | Unique, Auth0 identifier |
+| email | text | Unique |
+| name, nickname, phone | text | Profile info |
+| picture_url | text | Avatar |
+| date_of_birth | timestamp | |
+| emergency_contact_name | text | |
+| emergency_contact_phone | text | |
+| has_acting_skills, has_communication_skills, has_cooking_skills, has_dancing_skills, has_manual_skills, has_music_skills, has_singing_skills | boolean | Skill flags |
+| experience_type | enum | `newbie`, `experienced`, `coordinator` |
+| created_at, updated_at | timestamp | |
+
+**events**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| name | text | |
+| description | text | |
+| is_current | boolean | Marks the active event |
+| deleted_at | timestamp | Soft delete |
+| created_at, updated_at | timestamp | |
+
+**team_templates**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| name | text | |
+| key | text | Unique identifier |
+| description | text | Nullable |
+| created_at, updated_at | timestamp | |
+
+**team_instances**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| template_id | uuid | FK → team_templates |
+| event_id | uuid | FK → events |
+| first_coordinator_id | uuid | FK → users, nullable |
+| second_coordinator_id | uuid | FK → users, nullable |
+| created_at, updated_at | timestamp | |
+
+**team_memberships**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| user_id | uuid | FK → users |
+| team_instance_id | uuid | FK → team_instances |
+| created_at, updated_at | timestamp | |
+
+**subscriptions**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| user_id | uuid | FK → users |
+| event_id | uuid | FK → events |
+| status | enum | `pending`, `received`, `completed`, `waiting_list` |
+| availability | enum[] | Days of the week |
+| created_at, updated_at | timestamp | |
+
+**subscription_options**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | Primary key |
+| subscription_id | uuid | FK → subscriptions |
+| team_instance_id | uuid | FK → team_instances |
+| created_at, updated_at | timestamp | |
+
+### Relationships
+
+```
+users ─┬─< subscriptions >── events
+       │        │
+       │        └──< subscription_options >── team_instances
+       │
+       ├─< team_memberships >── team_instances
+       │
+       └── team_instances (as first/second coordinator)
+
+team_templates ─< team_instances >── events
+```

--- a/api/docs/features.md
+++ b/api/docs/features.md
@@ -1,0 +1,21 @@
+## Feature Modules
+
+### User
+
+Handles user synchronization with Auth0 and profile management. When a user logs in, their Auth0 profile is synced to the local database. Users can update personal info and skills.
+
+### Event
+
+Manages the event lifecycle from the subscriber's perspective. Handles event subscriptions (linking users to team preferences and availability), listing teams per event, listing subscriptions with filtering/pagination, and retrieving the current active event.
+
+### Team
+
+Manages team instances and memberships. Supports listing teams, viewing team details, adding/removing members, and assigning coordinators to teams.
+
+### Subscription
+
+Provides read access to subscriptions. Supports listing all subscriptions and retrieving individual subscription details.
+
+### Control Panel
+
+Admin-facing operations for managing the system. Handles full CRUD for team templates and events, including soft-deleting events, setting the current active event, and auto-creating team instances when a new event is created.

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,41 @@
+## Project Overview
+
+The Vite React app that supports EJC Hub - A event management application for managing events, teams, subscriptions, and users.
+
+## Tech Stack
+
+- **Framework:** React with TypeScript
+- **Build Tool:** Vite
+- **Styling:** Tailwind CSS
+- **Storybook:** For component documentation
+- **Testing:** Vitest
+- **Linting:** ESLint with Prettier
+- **Authentication:** Auth0
+
+## Code Conventions
+
+### File Naming
+
+- Components: `ComponentName/ComponentName.tsx`
+- Stories: `ComponentName/ComponentName.stories.tsx`
+- Hooks: `useHookName.ts` or `useHookName/useHookName.ts`
+- Pages: `PageName.tsx`
+
+### React Patterns
+
+- Use functional components with hooks.
+- Create Storybook stories for all reusable components.
+- Use custom hooks for reusable logic.
+- Keep components small and focused.
+- Do not destructure props in the function signature, use `props.propName` instead. Unless it needs a default value.
+- Do not destructure optional props in the function signature of type `boolean` since `false | undefined | null` will have the same behavior in these cases.
+- Handling Forms with React:
+  - Create a custom hook to encapsulate form handling. The file name for it must be `use<Form Intention>Form.ts`, for example `useSubscriptionForm.ts`.
+  - Any form libraries installed in the app must be used inside the _custom hook only_.
+  - If the form has more than 2 sections, split each session in it own component and file.
+    - When that happens, create a React Context with the Provider at the Form Parent Component, the children components must interact with the form via custom hook.
+
+## Testing
+
+- Vitest for component and hook tests.
+- Write stories for visual component testing.

--- a/common/CLAUDE.md
+++ b/common/CLAUDE.md
@@ -1,0 +1,20 @@
+## Project Overview
+
+The shared common utilities for the API and APP that supports EJC Hub - A event management application for managing events, teams, subscriptions, and users.
+
+## Tech Stack
+
+- **Runtime:** TypeScript
+- **Testing:** Jest
+
+## Code Conventions
+
+### File Naming
+
+- Every function MUST have it own set of files:
+  - `<functionName>.ts` the implementation of the function.
+  - `<functionName>.spec.ts` the unit test convering the use cases of the function.
+
+## Testing
+
+- Tests must cover at least one positive and one negative use case.


### PR DESCRIPTION
## Overview

Updated and reorganized the Claude documentation across the project. The root `CLAUDE.md` was simplified to contain only shared conventions, while detailed documentation was distributed to each package (`api/`, `app/`, `common/`) with their own `CLAUDE.md` files and supporting docs.

## Details

### Solution

- **Simplified root `CLAUDE.md`**: Removed detailed tech stack descriptions, file naming conventions, framework-specific patterns, and testing details that are specific to individual packages. Kept only the shared project overview, structure, and common conventions.

- **Created `api/CLAUDE.md`**: Contains API-specific tech stack, file naming, Fastify patterns, and database conventions. References new dedicated doc files for deeper context.

- **Created `api/docs/`**: Added detailed documentation files:
  - `architecture.md` — Folder structure, architecture layers (domain, core, repository, application, HTTP), core infrastructure, shared utilities, and design patterns.
  - `auth.md` — Authentication and authorization flow with Auth0, token extraction, and permission types.
  - `database-schema.md` — Full database schema with all tables, columns, types, and entity relationships.
  - `features.md` — Description of each feature module (User, Event, Team, Subscription, Control Panel).

- **Created `app/CLAUDE.md`**: Contains frontend-specific tech stack, file naming, React patterns, and form handling conventions.

- **Created `common/CLAUDE.md`**: Contains shared utilities conventions, file naming rules, and testing requirements.