### PR TITLE
feat: event subscription integration

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,8 @@
     "lint:fix": "eslint 'src/**/*.{ts,js}' --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "db:prepare": "drizzle-kit generate"
   },
   "keywords": [],
   "author": "",

--- a/api/src/core/database/migrations/0022_perfect_annihilus.sql
+++ b/api/src/core/database/migrations/0022_perfect_annihilus.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "subscriptions" ADD COLUMN "details" text DEFAULT '';--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD COLUMN "previous_experience_teams" text[] DEFAULT '{}';

--- a/api/src/core/database/migrations/meta/0022_snapshot.json
+++ b/api/src/core/database/migrations/meta/0022_snapshot.json
@@ -1,0 +1,684 @@
+{
+  "id": "1e58e139-ebd9-44e9-8634-e6dfcc393b4f",
+  "prevId": "21c21c8c-c4ee-4c84-b239-3fbc28262580",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_options": {
+      "name": "subscription_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_options_subscription_id_subscriptions_id_fk": {
+          "name": "subscription_options_subscription_id_subscriptions_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscription_options_team_instance_id_team_instances_id_fk": {
+          "name": "subscription_options_team_instance_id_team_instances_id_fk",
+          "tableFrom": "subscription_options",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "availability": {
+          "name": "availability",
+          "type": "subscription_availability[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "previous_experience_teams": {
+          "name": "previous_experience_teams",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subscriptions_event_id_events_id_fk": {
+          "name": "subscriptions_event_id_events_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_instances": {
+      "name": "team_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_coordinator_id": {
+          "name": "first_coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_coordinator_id": {
+          "name": "second_coordinator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_instances_template_id_team_templates_id_fk": {
+          "name": "team_instances_template_id_team_templates_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "team_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_event_id_events_id_fk": {
+          "name": "team_instances_event_id_events_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_first_coordinator_id_users_id_fk": {
+          "name": "team_instances_first_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "first_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_instances_second_coordinator_id_users_id_fk": {
+          "name": "team_instances_second_coordinator_id_users_id_fk",
+          "tableFrom": "team_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "second_coordinator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_instance_id": {
+          "name": "team_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_instance_id_team_instances_id_fk": {
+          "name": "team_memberships_team_instance_id_team_instances_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "team_instances",
+          "columnsFrom": [
+            "team_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_templates": {
+      "name": "team_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_templates_key_unique": {
+          "name": "team_templates_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_acting_skills": {
+          "name": "has_acting_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_communication_skills": {
+          "name": "has_communication_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_cooking_skills": {
+          "name": "has_cooking_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dancing_skills": {
+          "name": "has_dancing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_manual_skills": {
+          "name": "has_manual_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_music_skills": {
+          "name": "has_music_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_singing_skills": {
+          "name": "has_singing_skills",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experience_type": {
+          "name": "experience_type",
+          "type": "experience_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'experienced'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.subscription_availability": {
+      "name": "subscription_availability",
+      "schema": "public",
+      "values": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "received",
+        "completed",
+        "waiting_list"
+      ]
+    },
+    "public.experience_type": {
+      "name": "experience_type",
+      "schema": "public",
+      "values": [
+        "newbie",
+        "experienced",
+        "coordinator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/core/database/migrations/meta/_journal.json
+++ b/api/src/core/database/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1756243444155,
       "tag": "0021_dashing_mercury",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1771605280258,
+      "tag": "0022_perfect_annihilus",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/core/database/schemas/subscriptions.ts
+++ b/api/src/core/database/schemas/subscriptions.ts
@@ -1,4 +1,4 @@
-import { pgTable, timestamp, pgEnum, uuid } from 'drizzle-orm/pg-core'
+import { pgTable, timestamp, pgEnum, uuid, text } from 'drizzle-orm/pg-core'
 import { users } from './users.ts'
 import { events } from './events.ts'
 
@@ -29,6 +29,8 @@ export const subscriptions = pgTable('subscriptions', {
     .notNull(),
   status: subscriptionStatus().notNull().default('pending'),
   availability: subscriptionAvailability().notNull().array().default([]),
+  details: text('details').default(''),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  previousExperienceTeams: text('previous_experience_teams').notNull().array().default([]),
 })

--- a/api/src/features/control-panel/core/ControlPanel.ts
+++ b/api/src/features/control-panel/core/ControlPanel.ts
@@ -90,6 +90,10 @@ export class ControlPanel {
 
   async #createEventTeams(eventId: string) {
     const teamTemplates = await this.#teamTemplateRepository.listTeamTemplates()
+
+    if (teamTemplates.length === 0) {
+      return []
+    }
     const templateIds = teamTemplates.map((template) => template.id)
     const teamInstances = await this.#teamInstanceRepository.bulkInsertTeamInstances(
       eventId,

--- a/api/src/features/event/domain/subscription-types.ts
+++ b/api/src/features/event/domain/subscription-types.ts
@@ -16,8 +16,6 @@ export type SubscriptionPayload = {
   }
   skills: {
     hasActingSkills?: boolean
-    hasCoordinationSkills?: boolean
-    hasLogisticsSkills?: boolean
     hasCommunicationSkills?: boolean
     hasManualSkills?: boolean
     hasCookingSkills?: boolean
@@ -26,5 +24,19 @@ export type SubscriptionPayload = {
     hasSingingSkills?: boolean
   }
   options: string[]
+  availability: SubscriptionAvailability[]
+}
+
+export type CurrentEventSubscriptionPayload = {
+  fullName: string
+  nickname: string
+  email: string
+  phone: string
+  emergencyContactName: string
+  emergencyContactPhone: string
+  isNewbie?: boolean
+  hasCoordinatorExperience?: boolean
+  selectedSkills: string[]
+  selectedTeams: string[]
   availability: SubscriptionAvailability[]
 }

--- a/api/src/features/event/http/events.schema.ts
+++ b/api/src/features/event/http/events.schema.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod/v4'
+
+export const eventIdParamSchema = z.object({
+  eventId: z.uuid(),
+})
+
+export const subscriptionAvailabilityEnum = z.enum([
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+])
+
+export const subscribeBodySchema = z.object({
+  user: z.object({
+    emergencyContactName: z.string('emergency contact name is required').nonempty(),
+    emergencyContactPhone: z.string('emergency contact phone is required').nonempty(),
+    isNewbie: z.boolean().optional(),
+    hasCoordinatorExperience: z.boolean().optional(),
+  }),
+  skills: z.object({
+    hasActingSkills: z.boolean().optional(),
+    hasCommunicationSkills: z.boolean().optional(),
+    hasCookingSkills: z.boolean().optional(),
+    hasDancingSkills: z.boolean().optional(),
+    hasManualSkills: z.boolean().optional(),
+    hasMusicSkills: z.boolean().optional(),
+    hasSingingSkills: z.boolean().optional(),
+  }),
+  options: z.array(z.string()).length(3, 'Exactly 3 options are required'),
+  availability: z
+    .array(subscriptionAvailabilityEnum)
+    .min(1, 'At least one availability day is required'),
+})
+
+export const teamKeysQuerystringSchema = z.object({
+  teamKeys: z.preprocess((value) => {
+    if (typeof value === 'string') {
+      return value.split(',')
+    }
+  }, z.array(z.string()).optional()),
+})
+
+export const paginationQuerystringSchema = z.object({
+  page: z.coerce.number().int().min(1).optional(),
+  size: z.coerce.number().int().min(1).optional(),
+})
+
+export const listSubscriptionsQuerystringSchema = z.object({
+  name: z.string().optional(),
+  ...teamKeysQuerystringSchema.shape,
+  ...paginationQuerystringSchema.shape,
+})
+
+// TODO: this schema is currently duplicated with the one in the frontend, we should find a way to share it.
+// Creating a /common/contracts package that both frontend and backend can depend on would be ideal, but for now we can just copy it.
+export const subscribeCurrentSchema = z.object({
+  fullName: z.string('Full name is required').nonempty(),
+  nickname: z.string('Nickname is required').nonempty(),
+  email: z.email('Email is required'),
+  phone: z.string('Phone number is required').nonempty(),
+  emergencyContactName: z.string('Emergency contact name is required').nonempty(),
+  emergencyContactPhone: z.string('Emergency contact phone is required').nonempty(),
+  isNewbie: z.boolean().optional(),
+  hasCoordinatorExperience: z.boolean().optional(),
+  selectedSkills: z.array(z.string()),
+  selectedTeams: z.array(z.string()),
+  details: z.string().optional(),
+  previousExperienceTeams: z.array(z.string()),
+  availability: z
+    .array(subscriptionAvailabilityEnum)
+    .min(1, 'At least one availability day is required'),
+})

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -20,7 +20,6 @@ The Vite React app that supports EJC Hub - A event management application for ma
 - Components: `ComponentName/ComponentName.tsx`
 - Stories: `ComponentName/ComponentName.stories.tsx`
 - Hooks: `useHookName.ts` or `useHookName/useHookName.ts`
-- Pages: `PageName.tsx`
 
 ### React Patterns
 

--- a/app/src/components/TextArea/TextArea.stories.tsx
+++ b/app/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TextArea } from './TextArea'
+
+const meta = {
+  title: 'UI/TextArea',
+  component: TextArea,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TextArea>
+
+export const Primary = {
+  args: {
+    label: 'Descrição',
+    placeholder: 'Digite aqui...',
+  },
+} satisfies StoryObj
+
+export const Required = {
+  args: {
+    label: 'Experiência anterior',
+    placeholder: 'Descreva sua experiência...',
+    isRequired: true,
+  },
+} satisfies StoryObj
+
+export const Invalid = {
+  args: {
+    label: 'Descrição',
+    value: 'Texto inválido',
+    error: 'Esse campo é obrigatório',
+  },
+} satisfies StoryObj
+
+export default meta

--- a/app/src/components/TextArea/TextArea.tsx
+++ b/app/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,30 @@
+type TextAreaProps = {
+  label: string
+  name: string
+  placeholder?: string
+  isRequired?: boolean
+  value?: string
+  onChange?: (value: string) => void
+  error?: string
+  rows?: number
+}
+
+export function TextArea(props: TextAreaProps) {
+  return (
+    <div className="flex flex-col gap-1 w-full">
+      <label htmlFor={props.name} className="font-semibold text-sm text-gray-700">
+        {`${props.label}${props.isRequired ? '*' : ''}`}
+      </label>
+      <textarea
+        name={props.name}
+        required={props.isRequired}
+        className={`border py-2 px-3 rounded ${props.error ? 'border-red-400' : 'border-gray-400'} text-md text-black placeholder:text-gray-400 focus:outline-none focus:border-blue-500 resize-none`}
+        placeholder={props.placeholder}
+        value={props.value}
+        onChange={(event) => props.onChange?.(event.target.value)}
+        rows={props.rows ?? 4}
+      />
+      {props.error && <p className="text-sm text-red-500">{props.error}</p>}
+    </div>
+  )
+}

--- a/app/src/pages/EventSubscription/AvailabilitySection.tsx
+++ b/app/src/pages/EventSubscription/AvailabilitySection.tsx
@@ -1,0 +1,66 @@
+import { Card } from '../../components/Card/Card'
+import { Checkbox } from '../../components/Checkbox/Checkbox'
+import { useEventSubscriptionField } from './useEventSubscriptionForm'
+
+const availability = [
+  {
+    label: 'Segunda-feira',
+    value: 'monday',
+  },
+  {
+    label: 'Terça-feira',
+    value: 'tuesday',
+  },
+  {
+    label: 'Quarta-feira',
+    value: 'wednesday',
+  },
+  {
+    label: 'Quinta-feira',
+    value: 'thursday',
+  },
+  {
+    label: 'Sexta-feira',
+    value: 'friday',
+  },
+  {
+    label: 'Sábado',
+    value: 'saturday',
+  },
+  {
+    label: 'Domingo',
+    value: 'sunday',
+  },
+]
+
+export function AvailabilitySection() {
+  const selectedAvailability = useEventSubscriptionField('selectedAvailability')
+
+  const toggle = (day: string) => {
+    const current = selectedAvailability.field.value
+    const next = current.includes(day) ? current.filter((d) => d !== day) : [...current, day]
+    selectedAvailability.field.onChange(next)
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-4">
+        <h3 className="text-lg font-bold text-gray-900">Sua disponibilidade durante a semana</h3>
+        <p className="text-sm text-gray-500">
+          Dia de semanas contam como disponíveis apenas o horário da noite (após as 19h) e finais de
+          semana contam como disponíveis a maior parte do dia.
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-3">
+          {availability.map((day) => (
+            <Checkbox
+              key={day.value}
+              label={day.label}
+              checked={selectedAvailability.field.value.includes(day.value)}
+              onChange={() => toggle(day.value)}
+            />
+          ))}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/app/src/pages/EventSubscription/DetailsSection.tsx
+++ b/app/src/pages/EventSubscription/DetailsSection.tsx
@@ -1,0 +1,26 @@
+import { Card } from '../../components/Card/Card'
+import { TextArea } from '../../components/TextArea/TextArea'
+import { useEventSubscriptionField } from './useEventSubscriptionForm'
+
+export function DetailsSection() {
+  const details = useEventSubscriptionField('details')
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-4">
+        <div>
+          <h3 className="text-lg font-bold text-gray-900">Informações Adicionais</h3>
+          <p className="text-sm text-gray-500">
+            Qualquer informação que possa ser relevante para a montagem
+          </p>
+        </div>
+        <TextArea
+          label="Observações"
+          name="details"
+          value={details.field.value}
+          onChange={details.field.onChange}
+        />
+      </div>
+    </Card>
+  )
+}

--- a/app/src/pages/EventSubscription/EventSubscription.tsx
+++ b/app/src/pages/EventSubscription/EventSubscription.tsx
@@ -7,12 +7,31 @@ import { SkillsSection } from './SkillsSection'
 import { TeamSelectionSection } from './TeamSelectionSection'
 import { useEventSubscriptionForm } from './useEventSubscriptionForm'
 import type { EventSubscriptionFormData } from './useEventSubscriptionForm'
+import { AvailabilitySection } from './AvailabilitySection'
+import { DetailsSection } from './DetailsSection'
+import { useTeamOptionsQuery } from '../../services/teams/useTeamOptionsQuery'
+import { useCreateEventSubscriptionMutation } from '../../services/events/useCreateEventSubscriptionMutation'
 
 function EventSubscriptionForm() {
   const form = useEventSubscriptionForm()
+  const teamOptions = useTeamOptionsQuery()
+  const createEventSubscription = useCreateEventSubscriptionMutation()
 
-  const onSubmit = (data: EventSubscriptionFormData) => {
-    console.log('Form submitted:', data)
+  const onSubmit = async (data: EventSubscriptionFormData) => {
+    const payload = {
+      ...data,
+      isNewbie: data.hasPreviousExperience === 'no',
+      hasCoordinatorExperience: data.hasCoordinatorExperience === 'yes',
+      availability: data.selectedAvailability,
+      previousExperienceTeams: data.selectedPreviousExperienceTeams,
+    }
+
+    const response = await createEventSubscription.mutateAsync(payload)
+
+    if (response.status === 200 && response.data.id) {
+      // TODO: Show success message and redirect to confirmation page
+      alert('Inscrição realizada com sucesso!')
+    }
   }
 
   return (
@@ -26,10 +45,16 @@ function EventSubscriptionForm() {
       <div className="flex flex-col gap-6 text-left">
         <PersonalInformationSection />
         <EmergencyContactSection />
-        <PreviousExperienceSection />
+        <PreviousExperienceSection teamOptions={teamOptions.data ?? []} />
         <SkillsSection />
-        <TeamSelectionSection />
-        <Button variant="secondary" onClick={form.handleSubmit(onSubmit)}>
+        <AvailabilitySection />
+        <TeamSelectionSection teamOptions={teamOptions.data ?? []} />
+        <DetailsSection />
+        <Button
+          variant="secondary"
+          onClick={form.handleSubmit(onSubmit)}
+          disabled={createEventSubscription.isPending}
+        >
           Inscrever-se no Evento
         </Button>
       </div>

--- a/app/src/pages/EventSubscription/PersonalInformationSection.tsx
+++ b/app/src/pages/EventSubscription/PersonalInformationSection.tsx
@@ -6,6 +6,7 @@ export function PersonalInformationSection() {
   const fullName = useEventSubscriptionField('fullName')
   const email = useEventSubscriptionField('email')
   const phone = useEventSubscriptionField('phone')
+  const nickname = useEventSubscriptionField('nickname')
 
   return (
     <Card>
@@ -20,6 +21,13 @@ export function PersonalInformationSection() {
           placeholder="Digite seu nome completo"
           value={fullName.field.value}
           onChange={fullName.field.onChange}
+        />
+        <Input
+          label="Apelido"
+          name="nickname"
+          placeholder="Digite seu apelido"
+          value={nickname.field.value}
+          onChange={nickname.field.onChange}
         />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Input

--- a/app/src/pages/EventSubscription/PreviousExperienceSection.tsx
+++ b/app/src/pages/EventSubscription/PreviousExperienceSection.tsx
@@ -1,26 +1,69 @@
 import { Card } from '../../components/Card/Card'
+import { Checkbox } from '../../components/Checkbox/Checkbox'
 import { RadioGroup } from '../../components/RadioGroup/RadioGroup'
 import { useEventSubscriptionField } from './useEventSubscriptionForm'
 
+const ExperienceValue = {
+  Yes: 'yes',
+  No: 'no',
+} as const
+
 const experienceOptions = [
-  { label: 'Sim', value: 'yes' },
-  { label: 'Não', value: 'no' },
+  { label: 'Sim', value: ExperienceValue.Yes },
+  { label: 'Não', value: ExperienceValue.No },
 ]
 
-export function PreviousExperienceSection() {
+type PreviousExperienceSectionProps = {
+  teamOptions: { key: string; name: string; description: string }[]
+}
+
+export function PreviousExperienceSection(props: PreviousExperienceSectionProps) {
   const experience = useEventSubscriptionField('hasPreviousExperience')
+  const selectedPreviousExpTeams = useEventSubscriptionField('selectedPreviousExperienceTeams')
+  const hasCoordinatorExperience = useEventSubscriptionField('hasCoordinatorExperience')
+
+  const toggle = (teamKey: string) => {
+    const current = selectedPreviousExpTeams.field.value
+    const next = current.includes(teamKey)
+      ? current.filter((t) => t !== teamKey)
+      : [...current, teamKey]
+    selectedPreviousExpTeams.field.onChange(next)
+  }
 
   return (
     <Card>
       <h3 className="text-lg font-bold text-gray-900 mb-4">Experiência Anterior</h3>
       <RadioGroup
-        label="Você já participou de eventos antes?"
+        label="Você já serviu em algum Encontro de Jovens com Cristo antes?"
         description="Conte-nos sobre sua experiência anterior"
         options={experienceOptions}
         selected={experience.field.value}
         onChange={experience.field.onChange}
         variant="stacked"
       />
+      {experience.field.value === ExperienceValue.Yes && (
+        <div className="mt-4">
+          <p className="text-sm text-gray-500">Selecione as equipes em que você já serviu:</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3 mb-4">
+            {props.teamOptions.map((team) => (
+              <Checkbox
+                key={team.key}
+                label={team.name}
+                checked={selectedPreviousExpTeams.field.value.includes(team.key)}
+                onChange={() => toggle(team.key)}
+              />
+            ))}
+          </div>
+          <RadioGroup
+            label="Você já coordenou alguma equipe do EJC?"
+            description="Conte-nos sobre sua experiência coordenando"
+            options={experienceOptions}
+            selected={hasCoordinatorExperience.field.value}
+            onChange={hasCoordinatorExperience.field.onChange}
+            variant="stacked"
+          />
+        </div>
+      )}
     </Card>
   )
 }

--- a/app/src/pages/EventSubscription/SkillsSection.tsx
+++ b/app/src/pages/EventSubscription/SkillsSection.tsx
@@ -3,16 +3,34 @@ import { Checkbox } from '../../components/Checkbox/Checkbox'
 import { useEventSubscriptionField } from './useEventSubscriptionForm'
 
 const skills = [
-  'JavaScript',
-  'TypeScript',
-  'React',
-  'Python',
-  'Java',
-  'UI/UX Design',
-  'Gestão de Projetos',
-  'Análise de Dados',
-  'Marketing',
-  'Vendas',
+  {
+    label: 'Atuação',
+    value: 'has_acting_skills',
+  },
+  {
+    label: 'Dança',
+    value: 'has_dancing_skills',
+  },
+  {
+    label: 'Canta',
+    value: 'has_singing_skills',
+  },
+  {
+    label: 'Comunicação',
+    value: 'has_communication_skills',
+  },
+  {
+    label: 'Sabe cozinhar',
+    value: 'has_cooking_skills',
+  },
+  {
+    label: 'Habilidades manuais',
+    value: 'has_manual_skills',
+  },
+  {
+    label: 'Toca um instrumento',
+    value: 'has_music_skills',
+  },
 ]
 
 export function SkillsSection() {
@@ -34,10 +52,10 @@ export function SkillsSection() {
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-3">
           {skills.map((skill) => (
             <Checkbox
-              key={skill}
-              label={skill}
-              checked={selectedSkills.field.value.includes(skill)}
-              onChange={() => toggle(skill)}
+              key={skill.value}
+              label={skill.label}
+              checked={selectedSkills.field.value.includes(skill.value)}
+              onChange={() => toggle(skill.value)}
             />
           ))}
         </div>

--- a/app/src/pages/EventSubscription/TeamSelectionSection.tsx
+++ b/app/src/pages/EventSubscription/TeamSelectionSection.tsx
@@ -1,13 +1,15 @@
 import { Card } from '../../components/Card/Card'
 import { TeamBox } from '../../components/TeamBox/TeamBox'
 import { useEventSubscriptionField } from './useEventSubscriptionForm'
-import { mockTeams } from './teams.mock'
 
 const MAX_TEAMS = 3
 
-export function TeamSelectionSection() {
-  const selectedTeams = useEventSubscriptionField('selectedTeams')
+type TeamSelectionSectionProps = {
+  teamOptions: { key: string; name: string; description: string }[]
+}
 
+export function TeamSelectionSection(props: TeamSelectionSectionProps) {
+  const selectedTeams = useEventSubscriptionField('selectedTeams')
   const selectedCount = selectedTeams.field.value.length
   const isMaxSelected = selectedCount >= MAX_TEAMS
 
@@ -34,16 +36,16 @@ export function TeamSelectionSection() {
           interesses e habilidades.
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {mockTeams.map((team) => {
-            const isSelected = selectedTeams.field.value.includes(team.id)
+          {props.teamOptions.map((team) => {
+            const isSelected = selectedTeams.field.value.includes(team.key)
             return (
               <TeamBox
-                key={team.id}
-                title={team.title}
+                key={team.key}
+                title={team.name}
                 description={team.description}
                 selected={isSelected}
                 disabled={!isSelected && isMaxSelected}
-                onToggle={() => toggle(team.id)}
+                onToggle={() => toggle(team.key)}
               />
             )
           })}

--- a/app/src/pages/EventSubscription/teams.mock.ts
+++ b/app/src/pages/EventSubscription/teams.mock.ts
@@ -1,8 +1,0 @@
-export const mockTeams = [
-  { id: '1', title: 'Águias', description: 'Voando alto com visão aguçada e precisão' },
-  { id: '2', title: 'Lobos', description: 'Matilha unida com determinação feroz' },
-  { id: '3', title: 'Panteras', description: 'Ágeis e velozes com táticas furtivas' },
-  { id: '4', title: 'Falcões', description: 'Foco afiado e execução estratégica' },
-  { id: '5', title: 'Leões', description: 'Liderança ousada e coragem destemida' },
-  { id: '6', title: 'Ursos', description: 'Resiliência forte e poder constante' },
-]

--- a/app/src/pages/EventSubscription/useEventSubscriptionForm/EventSubscriptionContext.tsx
+++ b/app/src/pages/EventSubscription/useEventSubscriptionForm/EventSubscriptionContext.tsx
@@ -5,13 +5,18 @@ import { z } from 'zod'
 
 export const eventSubscriptionSchema = z.object({
   fullName: z.string(),
+  nickname: z.string(),
   email: z.string(),
   phone: z.string(),
   emergencyContactName: z.string(),
   emergencyContactPhone: z.string(),
   hasPreviousExperience: z.enum(['yes', 'no']),
+  hasCoordinatorExperience: z.enum(['yes', 'no']),
   selectedSkills: z.array(z.string()),
   selectedTeams: z.array(z.string()),
+  selectedAvailability: z.array(z.string()),
+  details: z.string().optional(),
+  selectedPreviousExperienceTeams: z.array(z.string()),
 })
 
 export type EventSubscriptionFormData = z.infer<typeof eventSubscriptionSchema>
@@ -28,6 +33,9 @@ export function EventSubscriptionProvider(props: { children: ReactNode }) {
       hasPreviousExperience: 'no',
       selectedSkills: [],
       selectedTeams: [],
+      selectedAvailability: [],
+      details: '',
+      selectedPreviousExperienceTeams: [],
     },
   })
 

--- a/app/src/services/events/events.api.ts
+++ b/app/src/services/events/events.api.ts
@@ -1,0 +1,10 @@
+import { api } from '../api'
+import type { CreateEventSubscriptionPayload } from './events.types'
+
+function createEventSubscription(payload: CreateEventSubscriptionPayload) {
+  return api.post('/events/current', payload)
+}
+
+export const eventsApi = {
+  createEventSubscription,
+}

--- a/app/src/services/events/events.types.ts
+++ b/app/src/services/events/events.types.ts
@@ -1,0 +1,15 @@
+export type CreateEventSubscriptionPayload = {
+  fullName: string
+  nickname: string
+  email: string
+  phone: string
+  emergencyContactName: string
+  emergencyContactPhone: string
+  isNewbie: boolean
+  hasCoordinatorExperience: boolean
+  selectedSkills: string[]
+  selectedTeams: string[]
+  details?: string
+  availability: string[]
+  previousExperienceTeams: string[]
+}

--- a/app/src/services/events/useCreateEventSubscriptionMutation.ts
+++ b/app/src/services/events/useCreateEventSubscriptionMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query'
+import { eventsApi } from './events.api'
+
+export function useCreateEventSubscriptionMutation() {
+  const mutation = useMutation({
+    mutationFn: eventsApi.createEventSubscription,
+  })
+
+  return mutation
+}

--- a/app/src/services/teams/teams.api.ts
+++ b/app/src/services/teams/teams.api.ts
@@ -1,0 +1,11 @@
+import { api } from '../api'
+import type { TeamOption } from './teams.types'
+
+async function getTeamOptions() {
+  const response = await api.get<{ teamOptions: TeamOption[] }>('/teams/options')
+  return response.data.teamOptions
+}
+
+export const teamsApi = {
+  getTeamOptions,
+}

--- a/app/src/services/teams/teams.types.ts
+++ b/app/src/services/teams/teams.types.ts
@@ -1,0 +1,9 @@
+export const teamOptionsQueryKeys = {
+  all: ['team-options'] as const,
+}
+
+export type TeamOption = {
+  key: string
+  name: string
+  description: string
+}

--- a/app/src/services/teams/useTeamOptionsQuery.ts
+++ b/app/src/services/teams/useTeamOptionsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
+import { teamsApi } from './teams.api'
+import { teamOptionsQueryKeys } from './teams.types'
+
+export function useTeamOptionsQuery() {
+  const query = useQuery({
+    queryKey: teamOptionsQueryKeys.all,
+    queryFn: teamsApi.getTeamOptions,
+  })
+
+  return query
+}


### PR DESCRIPTION
## Overview

Resolves: #151 #135 

Integrates the event subscription page with the backend API, replacing mock data with real API calls for team options and subscription creation. Adds new fields (`details` and `previous_experience_teams`) to the subscription flow, allowing users to provide additional context and past team experience when subscribing to events.

## Details

### Solution

- **API - New subscription fields:** Added `details` (text) and `previous_experience_teams` (text array) columns to the subscriptions table via migration. Updated the subscription creation endpoint schema and domain types to support these fields.
- **API - Event routes refactor:** Extracted Zod validation schemas into a dedicated `events.schema.ts` file. Added a new `GET /events/:id/team-options` endpoint that returns available teams for event subscription.
- **API - Control panel:** Registered the new team options route in the control panel feature.
- **App - API integration:** Created service layers for events (`useCreateEventSubscriptionMutation`) and teams (`useTeamOptionsQuery`) using React Query, replacing the hardcoded mock data.
- **App - Form sections updated:** Updated `AvailabilitySection`, `PreviousExperienceSection`, `SkillsSection`, and `TeamSelectionSection` to use real data from the API and the subscription context.
- **App - TextArea component:** Added a new reusable `TextArea` component with Storybook stories for the details field.
- **App - Subscription context:** Extended `EventSubscriptionContext` with new fields (`details`, `previousExperienceTeams`) and a submit handler that calls the API.